### PR TITLE
tests: Remove unnecessary `list()` casting on `call_args`

### DIFF
--- a/abstracts/tests/test_implements.py
+++ b/abstracts/tests/test_implements.py
@@ -159,10 +159,10 @@ def test_implementer_add_interfaces(patches, subc, missing):
 
     if not missing_ifaces:
         assert (
-            list(list(c) for c in m_subc.call_args_list)
+            m_subc.call_args_list
             == [[('KLASS', iface), {}] for iface in ifaces])
         assert (
-            list(list(c) for c in mock_register.call_args_list)
+            mock_register.call_args_list
             == [[(iface.x, 'KLASS', ), {}]
                 for iface in ifaces if iface.x not in subc])
         return
@@ -174,10 +174,10 @@ def test_implementer_add_interfaces(patches, subc, missing):
         == (f"Not all methods for interface {failed} "
             "provided: missing ['METHOD5', 'METHOD6']"))
     assert (
-        list(list(c) for c in m_subc.call_args_list)
+        m_subc.call_args_list
         == [[('KLASS', iface), {}] for iface in ifaces[:failed_index + 1]])
     assert (
-        list(list(c) for c in mock_register.call_args_list)
+        mock_register.call_args_list
         == [[(iface.x, 'KLASS', ), {}]
             for iface in ifaces[:failed_index] if iface.x not in subc])
 
@@ -202,10 +202,10 @@ def test_implementer_check_interface(patches, attrs, methods):
             abstracts.Implementer.check_interface(clsdict)
 
     assert (
-        list(m_attrs.call_args)
+        m_attrs.call_args
         == [(clsdict, ), {}])
     assert (
-        list(m_methods.call_args)
+        m_methods.call_args
         == [(clsdict, ), {}])
     if extra:
         assert (
@@ -428,36 +428,36 @@ def test_implementer_dunder_new(
 
     if has_implements:
         assert (
-            list(m_getifaces.call_args)
+            m_getifaces.call_args
             == [(bases, clsdict), {}])
         assert (
-            list(m_docs.call_args)
+            m_docs.call_args
             == [(clsdict, "NEW"), {}])
         assert not m_isiface.called
         assert not m_checkiface.called
         assert (
-            list(list(c) for c in mock_super.call_args_list)
+            mock_super.call_args_list
             == [[(), {}],
                 [('NAME', m_bases.return_value,
                   {'FOO': 'BAR', '__implements__': 'IMPLEMENTS'}), {}]])
         assert (
-            list(m_ifaces.call_args)
+            m_ifaces.call_args
             == [(m_getifaces.return_value, "NEW"), {}])
         return
     assert not m_ifaces.called
     assert not m_docs.called
     assert not m_getifaces.called
     assert (
-        list(list(c) for c in mock_super.call_args_list)
+        mock_super.call_args_list
         == [[(), {}],
             [('NAME', bases,
               {'FOO': 'BAR'}), {}]])
     assert (
-        list(m_isiface.call_args)
+        m_isiface.call_args
         == [("NEW", ), {}])
     if is_interface:
         assert (
-            list(m_checkiface.call_args)
+            m_checkiface.call_args
             == [(clsdict, ), {}])
     else:
         assert not m_checkiface.called

--- a/aio.api.github/tests/test_abstract_api.py
+++ b/aio.api.github/tests/test_abstract_api.py
@@ -85,7 +85,7 @@ def test_abstract_api_dunder_getitem(patches):
         assert api["REPO"] == m_repo_class.return_value.return_value
 
     assert (
-        list(m_repo_class.return_value.call_args)
+        m_repo_class.return_value.call_args
         == [(api, "REPO"), {}])
 
 
@@ -104,7 +104,7 @@ def test_abstract_api_api(patches):
             == m_api_class.return_value.return_value)
 
     assert (
-        list(m_api_class.return_value.call_args)
+        m_api_class.return_value.call_args
         == [args, kwargs])
 
     assert "api" in api.__dict__
@@ -126,7 +126,7 @@ async def test_abstract_api_getitem(patches):
             == m_api.return_value.getitem.return_value)
 
     assert (
-        list(m_api.return_value.getitem.call_args)
+        m_api.return_value.getitem.call_args
         == [args, kwargs])
 
 
@@ -147,7 +147,7 @@ def test_abstract_api_getiter(patches):
             == m_iter.return_value.return_value)
 
     assert (
-        list(m_iter.return_value.call_args)
+        m_iter.return_value.call_args
         == [(m_api.return_value, ) + args, kwargs])
 
 
@@ -167,7 +167,7 @@ async def test_abstract_api_patch(patches):
             == m_api.return_value.patch.return_value)
 
     assert (
-        list(m_api.return_value.patch.call_args)
+        m_api.return_value.patch.call_args
         == [args, kwargs])
 
 
@@ -187,7 +187,7 @@ async def test_abstract_api_post(patches):
             == m_api.return_value.post.return_value)
 
     assert (
-        list(m_api.return_value.post.call_args)
+        m_api.return_value.post.call_args
         == [args, kwargs])
 
 
@@ -212,14 +212,14 @@ def test_abstract_api_repo_from_url(patches, isrepo):
 
     repo_url = f"{m_api.return_value.base_url}/repos/"
     assert (
-        list(url.startswith.call_args)
+        url.startswith.call_args
         == [(repo_url, ), {}])
     if not isrepo:
         assert not m_get.called
         return
     assert (
-        list(m_get.call_args)
+        m_get.call_args
         == [("X/Y", ), {}])
     assert (
-        list(url.__getitem__.call_args)
+        url.__getitem__.call_args
         == [(slice(len(repo_url), None, None),), {}])

--- a/aio.api.github/tests/test_abstract_base.py
+++ b/aio.api.github/tests/test_abstract_base.py
@@ -44,13 +44,13 @@ def test_abstract_base_githubentity_dunder_getattr(
         assert (
             result
             == m_data.return_value.get.return_value.return_value)
-        call_args = list(m_data.return_value.get.call_args)
+        call_args = m_data.return_value.get.call_args
         assert call_args[0][0] == k
         marker = MagicMock()
         assert call_args[0][1](marker) is marker
         assert call_args[1] == {}
         assert (
-            list(m_data.return_value.get.return_value.call_args)
+            m_data.return_value.get.return_value.call_args
             == [(data[k], ), {}])
         return
     elif default != "UNSET":

--- a/aio.api.github/tests/test_abstract_commit.py
+++ b/aio.api.github/tests/test_abstract_commit.py
@@ -24,7 +24,7 @@ def test_abstract_commit_constructor(patches):
 
     assert isinstance(commit, github.abstract.base.GithubRepoEntity)
     assert (
-        list(m_super.call_args)
+        m_super.call_args
         == [args, kwargs])
     commit.repo = MagicMock()
     commit.sha = "SHA"
@@ -46,19 +46,19 @@ def test_abstract_commit_timestamp(patches):
             == m_utils.dt_from_js_isoformat.return_value)
 
     assert (
-        list(m_utils.dt_from_js_isoformat.call_args)
+        m_utils.dt_from_js_isoformat.call_args
         == [(data.__getitem__.return_value
                  .__getitem__.return_value
                  .__getitem__.return_value, ), {}])
     assert (
-        list(data.__getitem__.call_args)
+        data.__getitem__.call_args
         == [("commit", ), {}])
     assert (
-        list(data.__getitem__.return_value
-                 .__getitem__.call_args)
+        (data.__getitem__.return_value
+             .__getitem__.call_args)
         == [("committer", ), {}])
     assert (
-        list(data.__getitem__.return_value
-                 .__getitem__.return_value
-                 .__getitem__.call_args)
+        (data.__getitem__.return_value
+             .__getitem__.return_value
+             .__getitem__.call_args)
         == [("date", ), {}])

--- a/aio.api.github/tests/test_abstract_issues.py
+++ b/aio.api.github/tests/test_abstract_issues.py
@@ -34,7 +34,7 @@ def test_abstract_issue_constructor(patches):
 
     assert isinstance(issue, github.abstract.base.GithubRepoEntity)
     assert (
-        list(m_super.call_args)
+        m_super.call_args
         == [args, kwargs])
     issue.repo = MagicMock()
     issue.number = 23
@@ -73,7 +73,7 @@ async def test_abstract_issue_close(patches):
             await issue.close()
             == m_edit.return_value)
     assert (
-        list(m_edit.call_args)
+        m_edit.call_args
         == [(), dict(state="closed")])
 
 
@@ -86,7 +86,7 @@ async def test_abstract_issue_comment():
         await issue.comment("COMMENT")
         == repo.post.return_value)
     assert (
-        list(repo.post.call_args)
+        repo.post.call_args
         == [("issues/23/comments", ),
             dict(data=dict(body="COMMENT"))])
 
@@ -108,10 +108,10 @@ async def test_abstract_issue_edit(patches, kwargs):
 
     assert isinstance(result, github.AGithubIssue)
     assert (
-        list(m_init.call_args)
+        m_init.call_args
         == [(repo, repo.patch.return_value), {}])
     assert (
-        list(repo.patch.call_args)
+        repo.patch.call_args
         == [("issues/23", ), dict(data=kwargs)])
 
 
@@ -205,17 +205,17 @@ async def test_abstract_issues_create(repo1, repo2, raises):
                     f"{repo.name}\nRecieved: BOOM!"))
         assert not github.issue_class.called
         assert (
-            list(repo.post.call_args)
+            repo.post.call_args
             == [('issues',), data_kwargs])
     else:
         assert (
             await issues.create("ISSUE_TITLE", **kwargs)
             == github.issue_class.return_value)
         assert (
-            list(github.issue_class.call_args)
+            github.issue_class.call_args
             == [(repo, repo.post.return_value), {}])
     assert (
-        list(repo.post.call_args)
+        repo.post.call_args
         == [('issues',), data_kwargs])
 
 
@@ -248,7 +248,7 @@ def test_abstract_issues_inflater(patches, repo1, repo2):
         assert not m_partial.called
         return
     assert (
-        list(m_partial.call_args)
+        m_partial.call_args
         == [(github.issue_class, repo), {}])
 
 
@@ -271,14 +271,14 @@ def test_abstract_issues_search(patches, repo):
             == github.getiter.return_value)
 
     assert (
-        list(github.getiter.call_args)
+        github.getiter.call_args
         == [(m_query.return_value, ),
             dict(inflate=m_inflater.return_value)])
     assert (
-        list(m_query.call_args)
+        m_query.call_args
         == [("QUERY", ), {}])
     assert (
-        list(m_inflater.call_args)
+        m_inflater.call_args
         == [(repo, ), {}])
 
 
@@ -296,7 +296,7 @@ def test_abstract_issues_search_query(patches):
             == f"/search/issues?q={m_url.parse.quote.return_value}")
 
     assert (
-        list(m_url.parse.quote.call_args)
+        m_url.parse.quote.call_args
         == [(f"{m_filter.return_value}QUERY", ), {}])
 
 
@@ -308,8 +308,8 @@ def test_abstract_issues__inflate():
         issues._inflate(result)
         == github.issue_class.return_value)
     assert (
-        list(github.issue_class.call_args)
+        github.issue_class.call_args
         == [(github.repo_from_url.return_value, result), {}])
     assert (
-        list(github.repo_from_url.call_args)
+        github.repo_from_url.call_args
         == [("URL", ), {}])

--- a/aio.api.github/tests/test_abstract_iterator.py
+++ b/aio.api.github/tests/test_abstract_iterator.py
@@ -51,10 +51,10 @@ async def test_abstract_iterator_dunder_aiter(patches):
 
     assert results == [m_inflate.return_value] * len(iterables)
     assert (
-        list(list(c) for c in m_inflate.call_args_list)
+        m_inflate.call_args_list
         == [[(result,), {}] for result in iterables])
     assert (
-        list(iterator.api.api_iter.call_args)
+        iterator.api.api_iter.call_args
         == [('QUERY', ) + iterator.args, iterator.kwargs])
 
 
@@ -71,15 +71,15 @@ def test_abstract_iterator_count_request_headers(patches):
             == m_gidget.sansio.create_headers.return_value)
 
     assert (
-        list(m_gidget.sansio.create_headers.call_args)
+        m_gidget.sansio.create_headers.call_args
         == [(iterator.api.requester, ),
             dict(accept=m_gidget.sansio.accept_format.return_value,
                  oauth_token=iterator.api.oauth_token)])
     assert (
-        list(m_gidget.sansio.accept_format.call_args)
+        m_gidget.sansio.accept_format.call_args
         == [(), {}])
     assert (
-        list(m_gidget.sansio.create_headers.return_value.__setitem__.call_args)
+        m_gidget.sansio.create_headers.return_value.__setitem__.call_args
         == [("content-length", "0"), {}])
 
 
@@ -95,7 +95,7 @@ def test_abstract_iterator_count_url(patches):
             == m_gidget.sansio.format_url.return_value)
 
     assert (
-        list(m_gidget.sansio.format_url.call_args)
+        m_gidget.sansio.format_url.call_args
         == [("QUERY&per_page=1", {}),
             dict(base_url=iterator.api.base_url)])
 
@@ -124,10 +124,10 @@ async def test_abstract_iterator_total_count(patches, rate_limit):
     if rate_limit is not None:
         assert iterator.api.rate_limit.remaining == (rate_limit - 1)
     assert (
-        list(m_count.call_args)
+        m_count.call_args
         == [(iterator.api._request.return_value, ), {}])
     assert (
-        list(iterator.api._request.call_args)
+        iterator.api._request.call_args
         == [("GET", m_url.return_value, m_headers.return_value, b""), {}])
     assert (
         "total_count"
@@ -154,7 +154,7 @@ def test_abstract_iterator_count_from_data(patches, data):
         assert not m_int.called
         return
     assert (
-        list(m_int.call_args)
+        m_int.call_args
         == [(data["total_count"], ), {}])
 
 
@@ -178,7 +178,7 @@ def test_abstract_iterator_count_from_headers(patches, headers):
         assert not m_int.called
         return
     assert (
-        list(m_int.call_args)
+        m_int.call_args
         == [(headers["Link"].split.return_value
                             .__getitem__.return_value
                             .split.return_value
@@ -187,37 +187,37 @@ def test_abstract_iterator_count_from_headers(patches, headers):
                             .__getitem__.return_value, ), {}])
 
     assert (
-        list(headers["Link"].split.call_args)
+        headers["Link"].split.call_args
         == [(",", ), {}])
     assert (
-        list(headers["Link"].split.return_value
-                            .__getitem__.call_args)
+        (headers["Link"].split.return_value
+                        .__getitem__.call_args)
         == [(1, ), {}])
     assert (
-        list(headers["Link"].split.return_value
-                            .__getitem__.return_value
-                            .split.call_args)
+        (headers["Link"].split.return_value
+                        .__getitem__.return_value
+                        .split.call_args)
         == [(">", ), {}])
     assert (
-        list(headers["Link"].split.return_value
-                            .__getitem__.return_value
-                            .split.return_value
-                            .__getitem__.call_args)
+        (headers["Link"].split.return_value
+                        .__getitem__.return_value
+                        .split.return_value
+                        .__getitem__.call_args)
         == [(0, ), {}])
     assert (
-        list(headers["Link"].split.return_value
-                            .__getitem__.return_value
-                            .split.return_value
-                            .__getitem__.return_value
-                            .split.call_args)
+        (headers["Link"].split.return_value
+                        .__getitem__.return_value
+                        .split.return_value
+                        .__getitem__.return_value
+                        .split.call_args)
         == [("=", ), {}])
     assert (
-        list(headers["Link"].split.return_value
-                            .__getitem__.return_value
-                            .split.return_value
-                            .__getitem__.return_value
-                            .split.return_value
-                            .__getitem__.call_args)
+        (headers["Link"].split.return_value
+                        .__getitem__.return_value
+                        .split.return_value
+                        .__getitem__.return_value
+                        .split.return_value
+                        .__getitem__.call_args)
         == [(-1, ), {}])
 
 
@@ -254,7 +254,7 @@ def test_abstract_iterator_count_from_response(patches, header, data, code):
                     else m_data.return_value))
 
     assert (
-        list(m_gidgethub.sansio.decipher_response.call_args)
+        m_gidgethub.sansio.decipher_response.call_args
         == [tuple(response), {}])
 
     if code != 200:
@@ -265,13 +265,13 @@ def test_abstract_iterator_count_from_response(patches, header, data, code):
     assert iterator.api.rate_limit == 73
     if response[1]:
         assert (
-            list(m_headers.call_args)
+            m_headers.call_args
             == [(response[1], ), {}])
         assert not m_data.called
         return
     assert not m_headers.called
     assert (
-        list(m_data.call_args)
+        m_data.call_args
         == [(data and dict(total_count=23) or {}, ), {}])
 
 
@@ -293,5 +293,5 @@ def test_abstract_iterator_inflate(inflate):
         return
 
     assert (
-        list(iterator._inflate.call_args)
+        iterator._inflate.call_args
         == [(result, ), {}])

--- a/aio.api.github/tests/test_abstract_label.py
+++ b/aio.api.github/tests/test_abstract_label.py
@@ -22,7 +22,7 @@ def test_abstract_label_constructor(patches):
 
     assert isinstance(label, github.abstract.base.GithubRepoEntity)
     assert (
-        list(m_super.call_args)
+        m_super.call_args
         == [args, kwargs])
     label.name = "LABEL_NAME"
     assert (

--- a/aio.api.github/tests/test_abstract_release.py
+++ b/aio.api.github/tests/test_abstract_release.py
@@ -24,7 +24,7 @@ def test_abstract_release_constructor(patches):
 
     assert isinstance(release, github.abstract.base.GithubRepoEntity)
     assert (
-        list(m_super.call_args)
+        m_super.call_args
         == [args, kwargs])
     release.repo = MagicMock()
     release.tag_name = "RELEASE_NAME"
@@ -44,7 +44,7 @@ def test_abstract_release_dunder_data(patches):
         assert release.__data__ == m_dict.return_value
 
     assert (
-        list(m_dict.call_args)
+        m_dict.call_args
         == [(),
             dict(created_at=m_utils.dt_from_js_isoformat,
                  published_at=m_utils.dt_from_js_isoformat)])
@@ -63,7 +63,7 @@ def test_abstract_release_version(patches):
         assert release.version == m_version.parse.return_value
 
     assert (
-        list(m_version.parse.call_args)
+        m_version.parse.call_args
         == [("TAG_NAME", ), {}])
 
     assert "version" in release.__dict__

--- a/aio.api.github/tests/test_abstract_repo.py
+++ b/aio.api.github/tests/test_abstract_repo.py
@@ -79,7 +79,7 @@ def test_abstract_repo_github_path(patches):
         assert repo.github_path == m_plib.PurePosixPath.return_value
 
     assert (
-        list(m_plib.PurePosixPath.call_args)
+        m_plib.PurePosixPath.call_args
         == [("/repos/NAME", ), {}])
     assert "github_path" in repo.__dict__
 
@@ -89,7 +89,7 @@ def test_abstract_repo_issues(patches):
     repo = DummyGithubRepo(github, "NAME")
     assert repo.issues == github.issues_class.return_value
     assert (
-        list(github.issues_class.call_args)
+        github.issues_class.call_args
         == [(github, ), dict(repo=repo)])
     assert "issues" in repo.__dict__
 
@@ -105,7 +105,7 @@ def test_abstract_repo_labels(patches):
         assert repo.labels == m_iter.return_value
 
     assert (
-        list(m_iter.call_args)
+        m_iter.call_args
         == [(github.label_class, "labels"), {}])
     assert "labels" not in repo.__dict__
 
@@ -123,10 +123,10 @@ async def test_abstract_repo_commit(patches):
             == github.commit_class.return_value)
 
     assert (
-        list(github.commit_class.call_args)
+        github.commit_class.call_args
         == [(repo, m_getitem.return_value), {}])
     assert (
-        list(m_getitem.call_args)
+        m_getitem.call_args
         == [("commits/COMMIT_NAME", ), {}])
 
 
@@ -153,15 +153,15 @@ def test_abstract_repo_commits(patches, since):
     if since:
         query = f"{query}?since={m_utils.dt_to_js_isoformat.return_value}"
         assert (
-            list(m_utils.dt_to_js_isoformat.call_args)
+            m_utils.dt_to_js_isoformat.call_args
             == [(since, ), {}])
     else:
         assert not m_utils.dt_to_js_isoformat.called
     assert (
-        list(m_getiter.call_args)
+        m_getiter.call_args
         == [(query, ), dict(inflate=m_partial.return_value)])
     assert (
-        list(m_partial.call_args)
+        m_partial.call_args
         == [(github.commit_class, repo), {}])
 
 
@@ -179,10 +179,10 @@ async def test_abstract_repo_getitem(patches):
             == github.getitem.return_value)
 
     assert (
-        list(github.getitem.call_args)
+        github.getitem.call_args
         == [(m_gh_endpoint.return_value, ), {}])
     assert (
-        list(m_gh_endpoint.call_args)
+        m_gh_endpoint.call_args
         == [("QUERY", ), {}])
 
 
@@ -201,10 +201,10 @@ def test_abstract_repo_getiter(patches, kwargs):
             == github.getiter.return_value)
 
     assert (
-        list(github.getiter.call_args)
+        github.getiter.call_args
         == [(m_gh_endpoint.return_value, ), kwargs])
     assert (
-        list(m_gh_endpoint.call_args)
+        m_gh_endpoint.call_args
         == [("QUERY", ), {}])
 
 
@@ -221,7 +221,7 @@ def test_abstract_repo_github_endpoint(patches):
             == str(m_path.return_value.joinpath.return_value))
 
     assert (
-        list(m_path.return_value.joinpath.call_args)
+        m_path.return_value.joinpath.call_args
         == [("ENDPOINT", ), {}])
 
 
@@ -238,10 +238,10 @@ def test_abstract_repo_iter_entities(patches):
             == m_getiter.return_value)
 
     assert (
-        list(m_getiter.call_args)
+        m_getiter.call_args
         == [("PATH", ), dict(inflate=m_partial.return_value)])
     assert (
-        list(m_partial.call_args)
+        m_partial.call_args
         == [("ENTITY", repo), {}])
 
 
@@ -265,10 +265,10 @@ async def test_abstract_repo_patch(patches, data):
             == github.patch.return_value)
 
     assert (
-        list(github.patch.call_args)
+        github.patch.call_args
         == [(m_gh_endpoint.return_value, ), dict(data=data)])
     assert (
-        list(m_gh_endpoint.call_args)
+        m_gh_endpoint.call_args
         == [("QUERY", ), {}])
 
 
@@ -292,10 +292,10 @@ async def test_abstract_repo_post(patches, data):
             == github.post.return_value)
 
     assert (
-        list(github.post.call_args)
+        github.post.call_args
         == [(m_gh_endpoint.return_value, ), dict(data=data)])
     assert (
-        list(m_gh_endpoint.call_args)
+        m_gh_endpoint.call_args
         == [("QUERY", ), {}])
 
 
@@ -312,10 +312,10 @@ async def test_abstract_repo_release(patches):
             == github.release_class.return_value)
 
     assert (
-        list(github.release_class.call_args)
+        github.release_class.call_args
         == [(repo, m_getitem.return_value), {}])
     assert (
-        list(m_getitem.call_args)
+        m_getitem.call_args
         == [("releases/tags/RELEASE_NAME", ), {}])
 
 
@@ -332,7 +332,7 @@ def test_abstract_repo_releases(patches):
             == m_iter.return_value)
 
     assert (
-        list(m_iter.call_args)
+        m_iter.call_args
         == [(github.release_class, "releases?per_page=100"), {}])
 
 
@@ -359,23 +359,23 @@ async def test_abstract_repo_tag(patches, is_tag):
             == github.tag_class.return_value)
 
     assert (
-        list(github.tag_class.call_args)
+        github.tag_class.call_args
         == [(repo, github.getitem.return_value), {}])
     assert (
-        list(github.getitem.call_args)
+        github.getitem.call_args
         == [(m_getitem.return_value
                       .__getitem__.return_value
                       .__getitem__.return_value, ), {}])
     assert (
-        list(m_getitem.call_args)
+        m_getitem.call_args
         == [("git/ref/tags/TAG_NAME", ), {}])
     assert (
-        list(m_getitem.return_value.__getitem__.call_args)
+        m_getitem.return_value.__getitem__.call_args
         == [("object", ), {}])
     assert (
-        list(m_getitem.return_value
-                      .__getitem__.return_value
-                      .__getitem__.call_args)
+        (m_getitem.return_value
+                  .__getitem__.return_value
+                  .__getitem__.call_args)
         == [("url", ), {}])
 
 
@@ -392,5 +392,5 @@ def test_abstract_repo_tags(patches):
             == m_iter.return_value)
 
     assert (
-        list(m_iter.call_args)
+        m_iter.call_args
         == [(github.tag_class, "tags"), {}])

--- a/aio.api.github/tests/test_abstract_tag.py
+++ b/aio.api.github/tests/test_abstract_tag.py
@@ -24,7 +24,7 @@ def test_abstract_tag_constructor(patches):
 
     assert isinstance(tag, base_github.abstract.base.GithubRepoEntity)
     assert (
-        list(m_super.call_args)
+        m_super.call_args
         == [args, kwargs])
     tag.repo = MagicMock()
     tag.tag = "TAG_NAME"
@@ -41,7 +41,7 @@ async def test_abstract_tag_commit(patches):
         result
         == repo.commit.return_value)
     assert (
-        list(repo.commit.call_args)
+        repo.commit.call_args
         == [("SHA", ), {}])
     assert (
         getattr(

--- a/aio.api.github/tests/test_api.py
+++ b/aio.api.github/tests/test_api.py
@@ -17,7 +17,7 @@ def test_api_constructor(patches):
 
     assert isinstance(api, github.AGithubAPI)
     assert (
-        list(m_super.call_args)
+        m_super.call_args
         == [(api, ) + args, kwargs])
     assert api.commit_class == github.GithubCommit
     assert api.issue_class == github.GithubIssue

--- a/aio.api.github/tests/test_utils.py
+++ b/aio.api.github/tests/test_utils.py
@@ -16,10 +16,10 @@ def test_utils_dt_from_js_isoformat(patches):
             == m_dt.fromisoformat.return_value)
 
     assert (
-        list(m_dt.fromisoformat.call_args)
+        m_dt.fromisoformat.call_args
         == [(iso.replace.return_value, ), {}])
     assert (
-        list(iso.replace.call_args)
+        iso.replace.call_args
         == [("Z", "+00:00"), {}])
 
 
@@ -29,8 +29,8 @@ def test_utils_dt_to_js_isoformat():
         github.utils.dt_to_js_isoformat(dt)
         == dt.isoformat.return_value.replace.return_value)
     assert (
-        list(dt.isoformat.call_args)
+        dt.isoformat.call_args
         == [(), {}])
     assert (
-        list(dt.isoformat.return_value.replace.call_args)
+        dt.isoformat.return_value.replace.call_args
         == [("+00:00", "Z"), {}])

--- a/aio.core/tests/test_aio.py
+++ b/aio.core/tests/test_aio.py
@@ -29,19 +29,19 @@ async def test_subprocess_parallel(patches):
 
     assert results == returned
     assert (
-        list(m_future.call_args)
+        m_future.call_args
         == [(), {}])
     assert (
-        list(m_asyncio.as_completed.call_args)
+        m_asyncio.as_completed.call_args
         == [(tuple(
             m_asyncio.ensure_future.return_value
             for i in range(0, len(procs))), ), {}])
     kwargs["executor"] = m_future.return_value.__enter__.return_value
     assert (
-        list(list(c) for c in m_run.call_args_list)
+        m_run.call_args_list
         == [[(proc,), kwargs] for proc in procs])
     assert (
-        list(list(c) for c in m_asyncio.ensure_future.call_args_list)
+        m_asyncio.ensure_future.call_args_list
         == [[(m_run.return_value,), {}] for proc in procs])
 
 
@@ -80,8 +80,8 @@ async def test_subprocess_run(patches, loop, executor):
     kwargs.pop("loop", None)
 
     assert (
-        list(m_partial.call_args)
+        m_partial.call_args
         == [(m_subproc.run, ) + tuple(args), kwargs])
     assert (
-        list(m_loop.run_in_executor.call_args)
+        m_loop.run_in_executor.call_args
         == [(executor, m_partial.return_value), {}])

--- a/aio.core/tests/test_functional.py
+++ b/aio.core/tests/test_functional.py
@@ -81,7 +81,7 @@ async def test_functional_async_property(cache, raises, result):
             e2.value.args[0]
             == 'AN ITERATING ERROR OCCURRED')
         assert (
-            list(m_async.call_args_list)
+            m_async.call_args_list
             == [[(), {}]] * 2)
         return
 
@@ -102,7 +102,7 @@ async def test_functional_async_property(cache, raises, result):
     if not cache:
         assert results2 == results1
         assert (
-            list(list(c) for c in m_async.call_args_list)
+            m_async.call_args_list
             == [[(), {}]] * 4)
         assert not hasattr(klass, functional.async_property.cache_name)
         return
@@ -112,7 +112,7 @@ async def test_functional_async_property(cache, raises, result):
     assert await klass.prop == result
     assert await klass.prop == result
     assert (
-        list(list(c) for c in m_async.call_args_list)
+        m_async.call_args_list
         == [[(), {}]] * 2)
 
     iter_prop = getattr(

--- a/aio.core/tests/test_reader.py
+++ b/aio.core/tests/test_reader.py
@@ -21,7 +21,7 @@ def test_stream_reader_constructor(patches, size):
 
     kwargs.pop("size", None)
     assert (
-        list(m_super.call_args)
+        m_super.call_args
         == [tuple(args), kwargs])
     assert reader._size == size
     assert reader.size == size
@@ -58,7 +58,7 @@ async def test_stream_reader_dunder_aiter(patches, size):
         results
         == [f"CHUNK{i}" for i in range(0, 3)])
     assert (
-        list(list(c) for c in _chunker._read.call_args_list)
+        _chunker._read.call_args_list
         == [[(m_size.return_value, ), {}] for i in range(0, 4)])
 
 
@@ -98,16 +98,16 @@ async def test_stream_reader(patches, chunk_size):
 
     assert reader == m_reader.return_value
     assert (
-        list(m_plib.Path.call_args)
+        m_plib.Path.call_args
         == [("PATH", ), {}])
     assert (
-        list(m_aiofiles.open.call_args)
+        m_aiofiles.open.call_args
         == [(m_plib.Path.return_value, 'rb'), {}])
     assert (
-        list(m_reader.call_args)
+        m_reader.call_args
         == [(m_aiofiles.open.return_value.__aenter__.return_value,),
             {'chunk_size': chunk_size,
              'size': m_plib.Path.return_value.stat.return_value.st_size}])
     assert (
-        list(m_plib.Path.return_value.stat.call_args)
+        m_plib.Path.return_value.stat.call_args
         == [(), {}])

--- a/aio.core/tests/test_task.py
+++ b/aio.core/tests/test_task.py
@@ -49,10 +49,10 @@ def test_aio_concurrent_dunder_aiter(patches):
 
     assert concurrent.submit_task == m_asyncio.create_task.return_value
     assert (
-        list(m_submit.call_args)
+        m_submit.call_args
         == [(), {}])
     assert (
-        list(m_asyncio.create_task.call_args)
+        m_asyncio.create_task.call_args
         == [(m_submit.return_value, ), {}])
 
 
@@ -84,7 +84,7 @@ def test_aio_concurrent_closing_lock(patches):
         assert concurrent.closing_lock == m_asyncio.Lock.return_value
 
     assert (
-        list(m_asyncio.Lock.call_args)
+        m_asyncio.Lock.call_args
         == [(), {}])
     assert "closing_lock" in concurrent.__dict__
 
@@ -141,7 +141,7 @@ async def test_aio_concurrent_coros(patches, raises, close_raises):
 
     if raises == GeneratorExit:
         assert (
-            list(coros.aclose.call_args)
+            coros.aclose.call_args
             == [(), {}])
         return
 
@@ -163,7 +163,7 @@ def test_aio_concurrent_running_queue(patches):
         assert concurrent.running_queue == m_asyncio.Queue.return_value
 
     assert (
-        list(m_asyncio.Queue.call_args)
+        m_asyncio.Queue.call_args
         == [(), {}])
     assert "running_queue" in concurrent.__dict__
 
@@ -181,7 +181,7 @@ def test_aio_concurrent_default_limit(patches, cpus):
         assert concurrent.default_limit == m_min.return_value
 
     assert (
-        list(m_min.call_args)
+        m_min.call_args
         == [(32, (cpus or 0) + 4), {}])
     assert "default_limit" not in concurrent.__dict__
 
@@ -196,7 +196,7 @@ def test_aio_concurrent_consumes_async(patches):
         assert concurrent.consumes_async == m_inst.return_value
 
     assert (
-        list(m_inst.call_args)
+        m_inst.call_args
         == [(["CORO"],
              (types.AsyncGeneratorType,
               AsyncIterator,
@@ -214,7 +214,7 @@ def test_aio_concurrent_consumes_generator(patches):
         assert concurrent.consumes_generator == m_inst.return_value
 
     assert (
-        list(m_inst.call_args)
+        m_inst.call_args
         == [(["CORO"], (types.AsyncGeneratorType, types.GeneratorType)), {}])
     assert "consumes_generator" in concurrent.__dict__
 
@@ -260,7 +260,7 @@ def test_aio_concurrent_out(patches):
         assert concurrent.out == m_asyncio.Queue.return_value
 
     assert (
-        list(m_asyncio.Queue.call_args)
+        m_asyncio.Queue.call_args
         == [(), {}])
     assert "out" in concurrent.__dict__
 
@@ -290,7 +290,7 @@ def test_aio_concurrent_sem(patches):
         assert concurrent.sem == m_asyncio.Semaphore.return_value
 
     assert (
-        list(m_asyncio.Semaphore.call_args)
+        m_asyncio.Semaphore.call_args
         == [(m_limit.return_value, ), {}])
     assert "sem" in concurrent.__dict__
 
@@ -305,7 +305,7 @@ def test_aio_concurrent_submission_lock(patches):
         assert concurrent.submission_lock == m_asyncio.Lock.return_value
 
     assert (
-        list(m_asyncio.Lock.call_args)
+        m_asyncio.Lock.call_args
         == [(), {}])
     assert "submission_lock" in concurrent.__dict__
 
@@ -349,19 +349,19 @@ async def test_aio_concurrent_cancel(patches):
         assert not await concurrent.cancel()
 
     assert (
-        list(m_close.call_args)
+        m_close.call_args
         == [(), {}])
     assert (
-        list(m_sem.return_value.release.call_args)
+        m_sem.return_value.release.call_args
         == [(), {}])
     assert (
-        list(m_cancel.call_args)
+        m_cancel.call_args
         == [(), {}])
     assert (
-        list(m_coros.call_args)
+        m_coros.call_args
         == [(), {}])
     assert (
-        list(waiter.call_args)
+        waiter.call_args
         == [(), {}])
 
 
@@ -393,11 +393,11 @@ async def test_aio_concurrent_cancel_tasks(patches, bad):
         assert not await concurrent.cancel_tasks()
 
     assert (
-        list(list(c) for c in waiter.call_args_list)
+        waiter.call_args_list
         == [[(), {}]] * 7)
     for task in tasks:
         assert (
-            list(task.cancel.call_args)
+            task.cancel.call_args
             == [(), {}])
 
 
@@ -418,7 +418,7 @@ async def test_aio_concurrent_close(patches, closed):
         assert not m_lock.called
     else:
         assert (
-            list(m_lock.return_value.acquire.call_args)
+            m_lock.return_value.acquire.call_args
             == [(), {}])
 
 
@@ -452,11 +452,11 @@ async def test_aio_concurrent_close_coros(patches, consumes_generator, bad):
         assert not m_iter.called
         return
     assert (
-        list(m_iter.call_args)
+        m_iter.call_args
         == [(), {}])
     for coro in coros:
         assert (
-            list(coro.close.call_args)
+            coro.close.call_args
             == [(), {}])
 
 
@@ -473,16 +473,16 @@ async def test_aio_concurrent_create_task(patches):
         assert not await concurrent.create_task("CORO")
 
     assert (
-        list(m_running_queue.return_value.put_nowait.call_args)
+        m_running_queue.return_value.put_nowait.call_args
         == [(None, ), {}])
     assert (
-        list(m_task.call_args)
+        m_task.call_args
         == [("CORO", ), {}])
     assert (
-        list(m_asyncio.create_task.call_args)
+        m_asyncio.create_task.call_args
         == [(m_task.return_value, ), {}])
     assert (
-        list(m_rem.call_args)
+        m_rem.call_args
         == [(m_asyncio.create_task.return_value, ), {}])
 
 
@@ -506,7 +506,7 @@ async def test_aio_concurrent_exit_on_completion(patches, active, closed):
         assert not m_out.called
         return
     assert (
-        list(m_out.return_value.put.call_args)
+        m_out.return_value.put.call_args
         == [(aio.core.tasks.tasks._sentinel, ), {}])
 
 
@@ -526,7 +526,7 @@ def test_aio_concurrent_forget_task(patches, closed):
         assert not concurrent._running.remove.called
         return
     assert (
-        list(concurrent._running.remove.call_args)
+        concurrent._running.remove.call_args
         == [("TASK", ), {}])
 
 
@@ -609,22 +609,22 @@ async def test_aio_concurrent_on_task_complete(
         return
 
     assert (
-        list(m_out.return_value.put.call_args)
+        m_out.return_value.put.call_args
         == [("RESULT", ), {}])
     if nolimit:
         assert not m_sem.return_value.release.called
     else:
         assert (
-            list(m_sem.return_value.release.call_args)
+            m_sem.return_value.release.call_args
             == [(), {}])
     if decrement or decrement is None:
         assert (
-            list(m_running_queue.return_value.get_nowait.call_args)
+            m_running_queue.return_value.get_nowait.call_args
             == [(), {}])
     else:
         assert not m_running_queue.return_value.get_nowait.called
     assert (
-        list(m_complete.call_args)
+        m_complete.call_args
         == [(), {}])
 
 
@@ -680,16 +680,16 @@ async def test_aio_concurrent_output(
         # last one errored
         assert results == [f"RESULT {i}" for i in range(1, result_count)]
         assert (
-            list(list(c) for c in m_error.call_args_list)
+            m_error.call_args_list
             == [[(result,), {}] for result in results] + [[(exception,), {}]])
         assert (
-            list(m_cancel.call_args)
+            m_cancel.call_args
             == [(), {}])
         assert not m_close.called
         return
 
     assert (
-        list(list(c) for c in m_close.call_args_list)
+        m_close.call_args_list
         == [[(), {}]])
     assert not m_cancel.called
 
@@ -754,18 +754,18 @@ async def test_aio_concurrent_ready(
         assert not m_nolimit.called
         assert not m_sem.called
         assert (
-            list(list(c) for c in closer.order_mock.call_args_list)
+            closer.order_mock.call_args_list
             == [[('CLOSED',), {}]])
         return
     if nolimit:
         assert not m_sem.called
         assert (
-            list(list(c) for c in closer.order_mock.call_args_list)
+            closer.order_mock.call_args_list
             == [[('CLOSED',), {}],
                 [('NOLIMIT',), {}]])
         return
     assert (
-        list(list(c) for c in closer.order_mock.call_args_list)
+        closer.order_mock.call_args_list
         == [[('CLOSED',), {}],
             [('NOLIMIT',), {}],
             [('ACQUIRE',), {}],
@@ -778,10 +778,10 @@ def test_aio_concurrent_remember_task():
     task = MagicMock()
     assert not concurrent.remember_task(task)
     assert (
-        list(concurrent._running.append.call_args)
+        concurrent._running.append.call_args
         == [(task, ), {}])
     assert (
-        list(task.add_done_callback.call_args)
+        task.add_done_callback.call_args
         == [(concurrent.forget_task, ), {}])
 
 
@@ -881,10 +881,10 @@ async def test_aio_concurrent_submit(
         assert not m_exit.called
     else:
         assert (
-            list(m_lock.return_value.release.call_args)
+            m_lock.return_value.release.call_args
             == [(), {}])
         assert (
-            list(m_exit.call_args)
+            m_exit.call_args
             == [(), {}])
 
     if coros < 2:
@@ -908,10 +908,10 @@ async def test_aio_concurrent_submit(
 
     if iter_errors:
         assert (
-            list(list(c) for c in m_out.return_value.put.call_args_list)
+            m_out.return_value.put.call_args_list
             == [[(corolist[0], ), {}]])
         assert (
-            list(list(c) for c in m_inst.call_args_list)
+            m_inst.call_args_list
             == [[(corolist[0], aio.core.tasks.ConcurrentIteratorError), {}]])
         assert not m_ready.called
         assert not m_valid.called
@@ -921,32 +921,32 @@ async def test_aio_concurrent_submit(
 
     if valid_errors:
         assert (
-            list(list(c) for c in m_inst.call_args_list)
+            m_inst.call_args_list
             == [[(corolist[0], aio.core.tasks.ConcurrentIteratorError), {}]])
         assert (
-            list(list(c) for c in m_ready.call_args_list)
+            m_ready.call_args_list
             == [[(), {}]])
         assert (
-            list(list(c) for c in m_valid.call_args_list)
+            m_valid.call_args_list
             == [[(corolist[0], ), {}]])
         assert not m_complete.called
         assert not m_create.called
         assert (
-            list(list(c) for c in m_order.call_args_list)
+            m_order.call_args_list
             == ([[('ACQUIRE',), {}],
                  [(corolist[0],), {}]]))
         return
 
     assert not m_out.return_value.put.called
     assert (
-        list(list(c) for c in m_ready.call_args_list)
+        m_ready.call_args_list
         == [[(), {}]] * min(coros - 1, unready + 1 or 1))
     assert (
-        list(list(c) for c in m_valid.call_args_list)
+        m_valid.call_args_list
         == [[(corolist[i - 1], ), {}]
             for i in range(1, min(coros, unready + 1))])
     assert (
-        list(list(c) for c in m_order.call_args_list)
+        m_order.call_args_list
         == ([[('ACQUIRE',), {}]]
             + [[(corolist[i - 1],), {}]
                for i in range(1, min(coros, unready + 2))]
@@ -959,13 +959,13 @@ async def test_aio_concurrent_submit(
             error = list(c)[0][0]
             assert isinstance(error, aio.core.tasks.ConcurrentError)
             assert (
-                list(c)
+                c
                 == [(error,), {'decrement': False}])
         assert not m_create.called
         return
     assert not m_complete.called
     assert (
-        list(list(c) for c in m_create.call_args_list)
+        m_create.call_args_list
         == [[(corolist[i - 1],), {}]
             for i in range(1, min(coros, unready + 1))])
 
@@ -1000,7 +1000,7 @@ async def test_aio_concurrent_task(patches, raises):
         assert isinstance(result, aio.core.tasks.ConcurrentExecutionError)
         assert result.args[0] is exception
     assert (
-        list(m_complete.call_args)
+        m_complete.call_args
         == [(result, ), {}])
 
 
@@ -1047,7 +1047,7 @@ def test_aio_concurrent_validate_coro(patches, awaitable, state):
 
     awaits.close()
     assert (
-        list(m_state.call_args)
+        m_state.call_args
         == [(awaits, ), {}])
 
     if state != inspect.CORO_CREATED:

--- a/aio.core/tests/test_writer.py
+++ b/aio.core/tests/test_writer.py
@@ -19,7 +19,7 @@ def test_stream_writer_constructor(patches):
 
     assert isinstance(writer, stream.AsyncStream)
     assert (
-        list(m_super.call_args)
+        m_super.call_args
         == [tuple(args), kwargs])
 
 
@@ -45,10 +45,10 @@ async def test_stream_writer_stream_bytes(patches):
         assert not await writer.stream_bytes(response)
 
     assert (
-        list(response.content.iter_chunked.call_args)
+        response.content.iter_chunked.call_args
         == [(m_size.return_value, ), {}])
     assert (
-        list(list(c) for c in m_buffer.return_value.write.call_args_list)
+        m_buffer.return_value.write.call_args_list
         == [[(f'CHUNK{i}',), {}] for i in range(0, 3)])
 
 
@@ -66,9 +66,9 @@ async def test_stream_writer(patches, chunk_size):
 
     assert writer == m_writer.return_value
     assert (
-        list(m_aiofiles.open.call_args)
+        m_aiofiles.open.call_args
         == [("PATH", 'wb'), {}])
     assert (
-        list(m_writer.call_args)
+        m_writer.call_args
         == [(m_aiofiles.open.return_value.__aenter__.return_value,),
             {'chunk_size': chunk_size}])

--- a/aio.run.runner/tests/test_abstract.py
+++ b/aio.run.runner/tests/test_abstract.py
@@ -49,10 +49,10 @@ def test_command_args(patches):
             == known_args.return_value.__getitem__.return_value)
 
     assert (
-        list(known_args.call_args)
+        known_args.call_args
         == [(context.extra_args, ), {}])
     assert (
-        list(known_args.return_value.__getitem__.call_args)
+        known_args.return_value.__getitem__.call_args
         == [(0, ), {}])
 
 
@@ -70,10 +70,10 @@ def test_command_extra_args(patches):
             == known_args.return_value.__getitem__.return_value)
 
     assert (
-        list(known_args.call_args)
+        known_args.call_args
         == [(context.extra_args, ), {}])
     assert (
-        list(known_args.return_value.__getitem__.call_args)
+        known_args.return_value.__getitem__.call_args
         == [(1, ), {}])
 
 
@@ -90,10 +90,10 @@ def test_command_parser(patches):
             == m_argparse.ArgumentParser.return_value)
 
     assert (
-        list(m_argparse.ArgumentParser.call_args)
+        m_argparse.ArgumentParser.call_args
         == [(), dict(allow_abbrev=False)])
     assert (
-        list(m_addargs.call_args)
+        m_addargs.call_args
         == [(m_argparse.ArgumentParser.return_value, ), {}])
 
 
@@ -183,10 +183,10 @@ def test_commandrunner_command(patches):
             == m_commands.return_value.__getitem__.return_value.return_value)
 
     assert (
-        list(m_commands.return_value.__getitem__.call_args)
+        m_commands.return_value.__getitem__.call_args
         == [(m_args.return_value.command, ), {}])
     assert (
-        list(m_commands.return_value.__getitem__.return_value.call_args)
+        m_commands.return_value.__getitem__.return_value.call_args
         == [(runner, ), {}])
 
 
@@ -213,5 +213,5 @@ async def test_commandrunner_run(patches):
             == cmd_run.return_value)
 
     assert (
-        list(cmd_run.call_args)
+        cmd_run.call_args
         == [(), {}])

--- a/aio.run.runner/tests/test_decorators.py
+++ b/aio.run.runner/tests/test_decorators.py
@@ -87,7 +87,7 @@ async def test_catches(errors, async_fun, raises, args, kwargs):
             else await run.run_async(*args, **kwargs))
 
     assert (
-        list(run._runner.call_args)
+        run._runner.call_args
         == [args, kwargs])
 
     if not should_fail and raises:
@@ -98,7 +98,7 @@ async def test_catches(errors, async_fun, raises, args, kwargs):
             error
             == (str(_error) or repr(_error)))
         assert (
-            list(run.log.error.call_args)
+            run.log.error.call_args
             == [(error,), {}])
     else:
         assert not run.log.error.called
@@ -167,8 +167,8 @@ async def test_cleansup(async_fun, raises):
                 == run._runner.return_value)
 
     assert (
-        list(run._runner.call_args)
+        run._runner.call_args
         == [tuple(args), kwargs])
     assert (
-        list(run.cleanup.call_args)
+        run.cleanup.call_args
         == [(), {}])

--- a/aio.run.runner/tests/test_runner.py
+++ b/aio.run.runner/tests/test_runner.py
@@ -88,12 +88,12 @@ def test_runner_dunder_call(patches, raises):
 
     if not raises:
         assert (
-            list(m_asyncio.run.call_args)
+            m_asyncio.run.call_args
             == [(m_run.return_value, ), {}])
     else:
         assert not m_asyncio.run.called
     assert (
-        list(m_run.call_args)
+        m_run.call_args
         == [(), {}])
 
 
@@ -112,10 +112,10 @@ def test_runner_args(patches):
             == known_args.return_value.__getitem__.return_value)
 
     assert (
-        list(known_args.call_args)
+        known_args.call_args
         == [(('path1', 'path2', 'path3'),), {}])
     assert (
-        list(known_args.return_value.__getitem__.call_args)
+        known_args.return_value.__getitem__.call_args
         == [(0,), {}])
     assert "args" in run.__dict__
 
@@ -135,10 +135,10 @@ def test_runner_extra_args(patches):
             == known_args.return_value.__getitem__.return_value)
 
     assert (
-        list(known_args.call_args)
+        known_args.call_args
         == [(('path1', 'path2', 'path3'),), {}])
     assert (
-        list(known_args.return_value.__getitem__.call_args)
+        known_args.return_value.__getitem__.call_args
         == [(1,), {}])
     assert "extra_args" in run.__dict__
 
@@ -192,10 +192,10 @@ def test_runner_log_level(patches):
         assert run.log_level == m_dict.return_value.__getitem__.return_value
 
     assert (
-        list(m_dict.call_args)
+        m_dict.call_args
         == [(runner.runner.LOG_LEVELS, ), {}])
     assert (
-        list(m_dict.return_value.__getitem__.call_args)
+        m_dict.return_value.__getitem__.call_args
         == [(m_args.return_value.log_level,), {}])
     assert "log_level" in run.__dict__
 
@@ -216,10 +216,10 @@ def test_runner_parser(patches):
         assert run.parser == m_parser.ArgumentParser.return_value
 
     assert (
-        list(m_parser.ArgumentParser.call_args)
+        m_parser.ArgumentParser.call_args
         == [(), {"allow_abbrev": False}])
     assert (
-        list(m_add_args.call_args)
+        m_add_args.call_args
         == [(m_parser.ArgumentParser.return_value,), {}])
     assert "parser" in run.__dict__
 
@@ -234,7 +234,7 @@ def test_runner_path(patches):
         assert run.path == m_plib.Path.return_value
 
     assert (
-        list(m_plib.Path.call_args)
+        m_plib.Path.call_args
         == [(".", ), {}])
 
 
@@ -327,22 +327,22 @@ def test_runner_stdout(patches):
         assert run.stdout == m_log.getLogger.return_value
 
     assert (
-        list(m_log.getLogger.call_args)
+        m_log.getLogger.call_args
         == [('stdout',), {}])
     assert (
-        list(m_log.getLogger.return_value.setLevel.call_args)
+        m_log.getLogger.return_value.setLevel.call_args
         == [(m_level.return_value,), {}])
     assert (
-        list(m_log.StreamHandler.call_args)
+        m_log.StreamHandler.call_args
         == [(sys.stdout,), {}])
     assert (
-        list(m_log.Formatter.call_args)
+        m_log.Formatter.call_args
         == [('%(message)s',), {}])
     assert (
-        list(m_log.StreamHandler.return_value.setFormatter.call_args)
+        m_log.StreamHandler.return_value.setFormatter.call_args
         == [(m_log.Formatter.return_value,), {}])
     assert (
-        list(m_log.getLogger.return_value.addHandler.call_args)
+        m_log.getLogger.return_value.addHandler.call_args
         == [(m_log.StreamHandler.return_value,), {}])
 
 
@@ -361,14 +361,14 @@ def test_runner_tempdir(patches, missing):
 
     if missing:
         assert (
-            list(m_log.return_value.warning.call_args)
+            m_log.return_value.warning.call_args
             == [(("Tempdir created but instance has a `run` method "
                   "which is not decorated with `@runner.cleansup`"), ), {}])
     else:
         assert not m_log.called
 
     assert (
-        list(m_tmp.TemporaryDirectory.call_args)
+        m_tmp.TemporaryDirectory.call_args
         == [(), {}])
     assert "tempdir" in run.__dict__
 
@@ -383,10 +383,10 @@ def test_runner_verbosity(patches):
         assert run.verbosity == m_dict.return_value.__getitem__.return_value
 
     assert (
-        list(m_dict.call_args)
+        m_dict.call_args
         == [(runner.runner.LOG_LEVELS, ), {}])
     assert (
-        list(m_dict.return_value.__getitem__.call_args)
+        m_dict.return_value.__getitem__.call_args
         == [(m_args.return_value.verbosity,), {}])
     assert "verbosity" in run.__dict__
 
@@ -398,7 +398,7 @@ def test_runner_add_arguments():
     assert run.add_arguments(parser) is None
 
     assert (
-        list(list(c) for c in parser.add_argument.call_args_list)
+        parser.add_argument.call_args_list
         == [[('--verbosity',
               '-v'),
              {'choices': ['debug',
@@ -486,7 +486,7 @@ def test_runner__cleanup_tempdir(patches, cached):
 
     if cached:
         assert (
-            list(m_temp.return_value.cleanup.call_args)
+            m_temp.return_value.cleanup.call_args
             == [(), {}])
     else:
         assert not m_temp.called
@@ -504,5 +504,5 @@ async def test_runner_cleanup(patches):
         assert not await run.cleanup()
 
     assert (
-        list(m_temp.call_args)
+        m_temp.call_args
         == [(), {}])

--- a/envoy.base.utils/tests/test_abstract.py
+++ b/envoy.base.utils/tests/test_abstract.py
@@ -55,10 +55,10 @@ def test_bazel_query_query(patches):
         assert query.query("EXPRESSION") == m_handle.return_value
 
     assert (
-        list(m_handle.call_args)
+        m_handle.call_args
         == [(m_run.return_value, ), {}])
     assert (
-        list(m_run.call_args)
+        m_run.call_args
         == [("EXPRESSION", ), {}])
 
 
@@ -89,10 +89,10 @@ def test_bazel_query_handle_query_response(patches, failed):
         return
 
     assert (
-        list(response.stdout.strip.call_args)
+        response.stdout.strip.call_args
         == [(), {}])
     assert (
-        list(response.stdout.strip.return_value.split.call_args)
+        response.stdout.strip.return_value.split.call_args
         == [("\n", ), {}])
 
 
@@ -138,8 +138,8 @@ def test_bazel_query_run_query(patches):
             == m_sub.run.return_value)
 
     assert (
-        list(m_sub.run.call_args)
+        m_sub.run.call_args
         == [(m_command.return_value, ), kwargs])
     assert (
-        list(m_command.call_args)
+        m_command.call_args
         == [("EXPRESSION", ), {}])

--- a/envoy.base.utils/tests/test_utils.py
+++ b/envoy.base.utils/tests/test_utils.py
@@ -95,29 +95,29 @@ def test_util_coverage_with_data_file(patches):
         with utils.coverage_with_data_file("PATH") as tmprc:
             assert tmprc == m_join.return_value
     assert (
-        list(m_config.call_args)
+        m_config.call_args
         == [(), {}])
     assert (
-        list(m_config.return_value.read.call_args)
+        m_config.return_value.read.call_args
         == [('.coveragerc',), {}])
     config_dict = m_config.return_value.__getitem__
     assert (
-        list(config_dict.call_args)
+        config_dict.call_args
         == [('run',), {}])
     assert (
-        list(config_dict.return_value.__setitem__.call_args)
+        config_dict.return_value.__setitem__.call_args
         == [('data_file', 'PATH'), {}])
     assert (
-        list(m_tmp.call_args)
+        m_tmp.call_args
         == [(), {}])
     assert (
-        list(m_join.call_args)
+        m_join.call_args
         == [(m_tmp.return_value.__enter__.return_value, '.coveragerc'), {}])
     assert (
-        list(m_open.call_args)
+        m_open.call_args
         == [(m_join.return_value, 'w'), {}])
     assert (
-        list(m_config.return_value.write.call_args)
+        m_config.return_value.write.call_args
         == [(m_open.return_value.__enter__.return_value,), {}])
 
 
@@ -152,19 +152,19 @@ def test_util_extract(patches, tarballs):
         return
 
     assert (
-        list(m_plib.Path.call_args)
+        m_plib.Path.call_args
         == [("PATH", ), {}])
 
     for _extract in _extractions:
         assert (
-            list(_extract.extractall.call_args)
+            _extract.extractall.call_args
             == [(), dict(path="PATH")])
 
     assert (
-        list(m_open.call_args_list)
+        m_open.call_args_list
         == [[(tarb, ), {}] for tarb in tarballs])
     assert (
-        list(m_nested.call_args)
+        m_nested.call_args
         == [tuple(m_open.return_value for x in tarballs), {}])
 
 
@@ -182,10 +182,10 @@ def test_util_untar(patches, tarballs):
             assert tmpdir == m_extract.return_value
 
     assert (
-        list(m_tmp.call_args)
+        m_tmp.call_args
         == [(), {}])
     assert (
-        list(m_extract.call_args)
+        m_extract.call_args
         == [(m_tmp.return_value.__enter__.return_value, ) + tarballs, {}])
 
 
@@ -199,13 +199,13 @@ def test_util_from_yaml(patches):
         assert utils.from_yaml("PATH") == m_yaml.safe_load.return_value
 
     assert (
-        list(m_plib.Path.call_args)
+        m_plib.Path.call_args
         == [("PATH", ), {}])
     assert (
-        list(m_yaml.safe_load.call_args)
+        m_yaml.safe_load.call_args
         == [(m_plib.Path.return_value.read_text.return_value, ), {}])
     assert (
-        list(m_plib.Path.return_value.read_text.call_args)
+        m_plib.Path.return_value.read_text.call_args
         == [(), {}])
 
 
@@ -219,13 +219,13 @@ def test_util_to_yaml(patches):
         assert utils.to_yaml("DATA", "PATH") == m_plib.Path.return_value
 
     assert (
-        list(m_yaml.dump.call_args)
+        m_yaml.dump.call_args
         == [("DATA", ), {}])
     assert (
-        list(m_plib.Path.return_value.write_text.call_args)
+        m_plib.Path.return_value.write_text.call_args
         == [(m_yaml.dump.return_value, ), {}])
     assert (
-        list(m_plib.Path.call_args)
+        m_plib.Path.call_args
         == [("PATH", ), {}])
 
 
@@ -281,14 +281,14 @@ def test_typed(patches, casted):
                 == ("Value has wrong type or shape for Type "
                     f"TYPE: {m_elips.return_value}"))
             assert (
-                list(m_elips.call_args)
+                m_elips.call_args
                 == [("VALUE", 10), {}])
         else:
             assert utils.typed("TYPE", value) == value
             assert not m_elips.called
 
     assert (
-        list(m_try.call_args)
+        m_try.call_args
         == [("TYPE", value), {}])
 
 
@@ -359,7 +359,7 @@ def test_is_sha(patches, length, raises):
                     and not raises))
     if length == 40:
         assert (
-            list(m_int.call_args)
+            m_int.call_args
             == [(text, 16), {}])
     else:
         assert not m_int.called
@@ -399,11 +399,11 @@ def test_dt_to_utc_isoformat(patches):
                 .return_value.isoformat.return_value))
 
     assert (
-        list(dt.replace.call_args)
+        dt.replace.call_args
         == [(), dict(tzinfo=m_pytz.UTC)])
     assert (
-        list(dt.replace.return_value.date.call_args)
+        dt.replace.return_value.date.call_args
         == [(), {}])
     assert (
-        list(dt.replace.return_value.date.return_value.isoformat.call_args)
+        dt.replace.return_value.date.return_value.isoformat.call_args
         == [(), {}])

--- a/envoy.code_format.python_check/tests/test_abstract.py
+++ b/envoy.code_format.python_check/tests/test_abstract.py
@@ -36,7 +36,7 @@ def test_abstract_python_checker_diff_path(patches, diff_path):
 
     if diff_path:
         assert (
-            list(m_plib.Path.call_args)
+            m_plib.Path.call_args
             == [(m_args.return_value.diff_file, ), {}])
     else:
         assert not m_plib.Path.called
@@ -53,10 +53,10 @@ def test_abstract_python_checker_flake8_app(patches):
         assert checker.flake8_app == m_flake8_app.return_value
 
     assert (
-        list(m_flake8_app.call_args)
+        m_flake8_app.call_args
         == [(), {}])
     assert (
-        list(m_flake8_app.return_value.initialize.call_args)
+        m_flake8_app.return_value.initialize.call_args
         == [(m_flake8_args.return_value,), {}])
 
 
@@ -87,7 +87,7 @@ def test_abstract_python_checker_flake8_config_path(patches):
             == m_path.return_value.joinpath.return_value)
 
     assert (
-        list(m_path.return_value.joinpath.call_args)
+        m_path.return_value.joinpath.call_args
         == [(python_check.abstract.FLAKE8_CONFIG, ), {}])
 
 
@@ -113,7 +113,7 @@ def test_abstract_python_checker_yapf_config_path(patches):
             == m_path.return_value.joinpath.return_value)
 
     assert (
-        list(m_path.return_value.joinpath.call_args)
+        m_path.return_value.joinpath.call_args
         == [(python_check.abstract.YAPF_CONFIG, ), {}])
 
 
@@ -131,12 +131,12 @@ def test_abstract_python_checker_yapf_files(patches):
         assert checker.yapf_files == m_yapf_files.return_value
 
     assert (
-        list(m_yapf_files.call_args)
+        m_yapf_files.call_args
         == [(m_args.return_value.paths,),
             {'recursive': m_args.return_value.recurse,
              'exclude': m_yapf_exclude.return_value}])
     assert (
-        list(m_yapf_exclude.call_args)
+        m_yapf_exclude.call_args
         == [(str(m_path.return_value),), {}])
 
 
@@ -151,10 +151,10 @@ def test_abstract_python_checker_add_arguments(patches):
         checker.add_arguments(m_parser)
 
     assert (
-        list(m_add.call_args)
+        m_add.call_args
         == [(m_parser,), {}])
     assert (
-        list(list(c) for c in m_parser.add_argument.call_args_list)
+        m_parser.add_argument.call_args_list
         == [[('--recurse', '-r'),
              {'choices': ['yes', 'no'],
               'default': 'yes',
@@ -185,18 +185,18 @@ async def test_abstract_python_checker_check_flake8(patches, errors):
         assert not await checker.check_flake8()
 
     assert (
-        list(m_buffered.call_args)
+        m_buffered.call_args
         == [(), {'stdout': errors, 'mangle': m_mangle}])
     assert (
-        list(m_flake8_app.return_value.run_checks.call_args)
+        m_flake8_app.return_value.run_checks.call_args
         == [(), {}])
     assert (
-        list(m_flake8_app.return_value.report.call_args)
+        m_flake8_app.return_value.report.call_args
         == [(), {}])
 
     if errors:
         assert (
-            list(m_error.call_args)
+            m_error.call_args
             == [('flake8', ['err1', 'err2']), {}])
     else:
         assert not m_error.called
@@ -236,10 +236,10 @@ async def test_abstract_python_checker_check_yapf(patches):
         assert not await checker.check_yapf()
 
     assert (
-        list(list(c) for c in m_yapf_format.call_args_list)
+        m_yapf_format.call_args_list
         == [[(file,), {}] for file in files])
     assert (
-        list(list(c) for c in m_yapf_result.call_args_list)
+        m_yapf_result.call_args_list
         == [[(m_yapf_format.return_value, f"REFORMAT{i}", f"CHANGED{i}"), {}]
             for i, _ in enumerate(files)])
 
@@ -269,7 +269,7 @@ async def test_abstract_python_checker_on_check_run(patches, errors, warnings):
         assert not m_succeed.called
     else:
         assert (
-            list(m_succeed.call_args)
+            m_succeed.call_args
             == [(checkname, [checkname]), {}])
 
 
@@ -298,17 +298,17 @@ async def test_abstract_python_checker_on_checks_complete(
 
     if diff_path and failed:
         assert (
-            list(m_run.call_args)
+            m_run.call_args
             == [(['git', 'diff', 'HEAD'],),
                 dict(capture_output=True, cwd=m_path.return_value)])
         assert (
-            list(m_diff.return_value.write_bytes.call_args)
+            m_diff.return_value.write_bytes.call_args
             == [(m_run.return_value.stdout,), {}])
     else:
         assert not m_run.called
 
     assert (
-        list(m_super.call_args)
+        m_super.call_args
         == [(), {}])
 
 
@@ -328,13 +328,13 @@ async def test_abstract_python_checker_yapf_format(patches, fix):
             == ("FILENAME", m_format.return_value))
 
     assert (
-        list(m_format.call_args)
+        m_format.call_args
         == [('FILENAME',),
             {'style_config': str(m_config.return_value),
              'in_place': fix,
              'print_diff': not fix}])
     assert (
-        list(list(c) for c in m_fix.call_args_list)
+        m_fix.call_args_list
         == [[(), {}], [(), {}]])
 
 
@@ -357,7 +357,7 @@ def test_abstract_python_checker_yapf_result(
 
     if not changed:
         assert (
-            list(m_succeed.call_args)
+            m_succeed.call_args
             == [('yapf', ['FILENAME']), {}])
         assert not m_warn.called
         assert not m_error.called
@@ -368,19 +368,19 @@ def test_abstract_python_checker_yapf_result(
         assert not m_error.called
         assert len(m_warn.call_args_list) == 1
         assert (
-            list(m_warn.call_args)
+            m_warn.call_args
             == [('yapf', ['FILENAME: reformatted']), {}])
         return
     if reformatted:
         assert not m_error.called
         assert len(m_warn.call_args_list) == 1
         assert (
-            list(m_warn.call_args)
+            m_warn.call_args
             == [('yapf', [f'FILENAME: diff\n{reformatted}']), {}])
         return
     assert not m_warn.called
     assert (
-        list(m_error.call_args)
+        m_error.call_args
         == [('yapf', ['FILENAME']), {}])
 
 
@@ -396,7 +396,7 @@ def test_abstract_python_checker_strip_lines():
             == [m_strip.return_value] * 3)
 
     assert (
-        list(list(c) for c in m_strip.call_args_list)
+        m_strip.call_args_list
         == [[('foo',), {}], [('bar',), {}], [('baz',), {}]])
 
 

--- a/envoy.dependency.cve_scan/tests/test_checker.py
+++ b/envoy.dependency.cve_scan/tests/test_checker.py
@@ -92,23 +92,23 @@ def test_checker_config(patches, start_config, start_raises):
             assert checker.config == m_dict.return_value
 
     assert (
-        list(m_dict.call_args)
+        m_dict.call_args
         == [(), dict(nist_url=m_tpl.return_value, start_year=0)])
     assert (
-        list(m_dict.return_value.update.call_args)
+        m_dict.return_value.update.call_args
         == [(m_utils.typed.return_value, ), {}])
     assert (
-        list(m_utils.typed.call_args)
+        m_utils.typed.call_args
         == [(m_dict, m_utils.from_yaml.return_value), {}])
     assert (
-        list(m_utils.from_yaml.call_args)
+        m_utils.from_yaml.call_args
         == [(m_path.return_value, ), {}])
     assert (
-        list(m_dict.return_value.__getitem__.call_args)
+        m_dict.return_value.__getitem__.call_args
         == [("start_year", ), {}])
     if start_config == 0 and not start_raises:
         assert (
-            list(m_dict.return_value.__setitem__.call_args)
+            m_dict.return_value.__setitem__.call_args
             == [("start_year", m_start.return_value), {}])
     else:
         assert not m_dict.return_value.__setitem__.called
@@ -127,7 +127,7 @@ def test_checker_config_path(patches):
         assert checker.config_path == m_plib.Path.return_value
 
     assert (
-        list(m_plib.Path.call_args)
+        m_plib.Path.call_args
         == [(m_args.return_value.config_path, ), {}])
     assert "config_path" not in checker.__dict__
 
@@ -158,14 +158,14 @@ async def test_checker_cve_data(patches):
             == (m_dict.return_value, m_ddict.return_value))
 
     assert (
-        list(list(c) for c in m_log.return_value.info.call_args_list)
+        m_log.return_value.info.call_args_list
         == [[(f"CVE data downloaded from: {dl.url}", ), {}]
             for dl in download_mocks])
     assert (
-        list(m_conc.call_args)
+        m_conc.call_args
         == [(m_nist.return_value,), {}])
     assert (
-        list(list(c) for c in m_parse.call_args_list)
+        m_parse.call_args_list
         == [[(dl, m_dict.return_value, m_ddict.return_value), {}]
             for dl in download_mocks])
     assert "cve_data" not in checker.__dict__
@@ -186,7 +186,7 @@ def test_checker_dependencies(patches):
                 for i in range(0, 5)])
 
     assert (
-        list(m_dep_class.return_value.call_args_list)
+        m_dep_class.return_value.call_args_list
         == [[(f"k{i}", f"v{i}"), {}] for i in range(0, 5)])
     assert "dependencies" in checker.__dict__
 
@@ -201,7 +201,7 @@ def test_checker_ignored_cves(patches):
         assert checker.ignored_cves == m_config.return_value.get.return_value
 
     assert (
-        list(m_config.return_value.get.call_args)
+        m_config.return_value.get.call_args
         == [("ignored_cves", []), {}])
     assert "ignored_cves" not in checker.__dict__
 
@@ -222,7 +222,7 @@ def test_checker_nist_downloads(patches):
             == [m_download.return_value for i in range(0, 5)])
 
     assert (
-        list(list(c) for c in m_download.call_args_list)
+        m_download.call_args_list
         == [[(f'URL{i}',), {}] for i in range(0, 5)])
 
     assert "nist_downloads" not in checker.__dict__
@@ -258,10 +258,10 @@ def test_checker_scan_year_end(patches):
             == m_dt.now.return_value.year.__add__.return_value)
 
     assert (
-        list(m_dt.now.call_args)
+        m_dt.now.call_args
         == [(), {}])
     assert (
-        list(m_dt.now.return_value.year.__add__.call_args)
+        m_dt.now.return_value.year.__add__.call_args
         == [(1, ), {}])
     assert "scan_year_end" not in checker.__dict__
 
@@ -279,7 +279,7 @@ def test_checker_scan_year_start(patches):
             == m_config.return_value.__getitem__.return_value)
 
     assert (
-        list(m_config.return_value.__getitem__.call_args)
+        m_config.return_value.__getitem__.call_args
         == [("start_year", ), {}])
 
     assert "scan_year_start" not in checker.__dict__
@@ -297,7 +297,7 @@ def test_checker_scan_years(patches):
         assert checker.scan_years == m_range.return_value
 
     assert (
-        list(m_range.call_args)
+        m_range.call_args
         == [(m_start.return_value, m_end.return_value), {}])
 
     assert "scan_years" not in checker.__dict__
@@ -313,7 +313,7 @@ def test_checker_session(patches):
         assert checker.session == m_aiohttp.ClientSession.return_value
 
     assert (
-        list(m_aiohttp.ClientSession.call_args)
+        m_aiohttp.ClientSession.call_args
         == [(), {}])
 
     assert "session" in checker.__dict__
@@ -363,9 +363,7 @@ def test_checker_urls(patches, provided_urls):
         return
 
     assert (
-        list(list(c)
-             for c
-             in m_config.return_value.__getitem__.call_args_list)
+        m_config.return_value.__getitem__.call_args_list
         == [[('nist_url',), {}]] * 5)
 
 
@@ -380,10 +378,10 @@ def test_checker_add_arguments(patches):
         assert not checker.add_arguments(parser)
 
     assert (
-        list(m_super.call_args)
+        m_super.call_args
         == [(parser, ), {}])
     assert (
-        list(list(c) for c in parser.add_argument.call_args_list)
+        parser.add_argument.call_args_list
         == [[('config_path',), {}], [('urls',), {'nargs': '*'}]])
 
 
@@ -419,25 +417,25 @@ async def test_checker_check_cves(patches):
         assert not await checker.check_cves()
 
     assert (
-        list(list(c) for c in m_log.return_value.info.call_args_list)
+        m_log.return_value.info.call_args_list
         == [[(f"No CPE listed for: {deps[1].id}", ), {}]])
     assert (
-        list(list(c) for c in m_check.call_args_list)
+        m_check.call_args_list
         == [[(dep, *cve_data), {}]
             for i, dep in enumerate(deps) if i != 1])
     formatted_failure = (
         f"{cve_data[0].__getitem__.return_value.format_failure.return_value}")
     assert (
-        list(list(c) for c in m_error.call_args_list)
+        m_error.call_args_list
         == [[('cves',
               [formatted_failure
                for fail in dep.errors]), {}]
             for i, dep in enumerate(deps) if i in [2, 3]])
     assert (
-        list(list(c) for c in cve_data[0].__getitem__.call_args_list)
+        cve_data[0].__getitem__.call_args_list
         == [[(i, ), {}] for i in [1, 3, 5, 2, 4]])
     assert (
-        list(list(c) for c in m_succeed.call_args_list)
+        m_succeed.call_args_list
         == [[('cves',
               [f"No CVEs found for: {dep.id}"]), {}]
             for i, dep in enumerate(deps) if i not in [1, 2, 3]])
@@ -484,19 +482,17 @@ def test_checker_dependency_match(patches, exclude_cves, cve_len, match_cves):
                 if i in match_cves])
 
     assert (
-        list(m_class.return_value.from_string.call_args)
+        m_class.return_value.from_string.call_args
         == [(dependency.cpe, ), {}])
     assert (
-        list(cpe_revmap.get.call_args)
+        cpe_revmap.get.call_args
         == [(m_class.return_value.from_string.return_value.vendor_normalized,
              []), {}])
     assert (
-        list(list(c) for c in cves.__getitem__.call_args_list)
+        cves.__getitem__.call_args_list
         == [[(cve, ), {}] for cve in cpe_cves])
     assert (
-        list(list(c)
-             for c
-             in cves.__getitem__.return_value.dependency_match.call_args_list)
+        cves.__getitem__.return_value.dependency_match.call_args_list
         == [[(dependency, ), {}] for cve in cpe_cves])
 
 
@@ -513,7 +509,7 @@ async def test_checker_download(patches):
         assert await checker.download("URL") == aget.return_value
 
     assert (
-        list(aget.call_args)
+        aget.call_args
         == [("URL", ), {}])
 
 
@@ -551,7 +547,7 @@ async def test_checker_on_checks_complete(patches):
         assert await checker.on_checks_complete() == m_super.return_value
 
     assert (
-        list(m_session.return_value.close.call_args)
+        m_session.return_value.close.call_args
         == [(), {}])
 
 
@@ -582,15 +578,15 @@ def test_checker_parse_cve_json(patches, exclude_cves):
         assert not checker.parse_cve_json(cve_json, cve_dict, cpe_revmap)
 
     assert (
-        list(list(c) for c in m_class.return_value.call_args_list)
+        m_class.return_value.call_args_list
         == [[(cve_item, m_tracked.return_value), {}]
             for cve_item in cve_items])
     assert (
-        list(list(c) for c in m_include.call_args_list)
+        m_include.call_args_list
         == [[(cve, ), {}]
             for cve in cves])
     assert (
-        list(list(c) for c in cve_dict.__setitem__.call_args_list)
+        cve_dict.__setitem__.call_args_list
         == [[(cve.id, cve), {}]
             for i, cve in enumerate(cves) if i not in exclude_cves])
     expected = []
@@ -600,12 +596,10 @@ def test_checker_parse_cve_json(patches, exclude_cves):
         for cpe in cve.cpes:
             expected.append((cpe, cve))
     assert (
-        list(list(c) for c in cpe_revmap.__getitem__.call_args_list)
+        cpe_revmap.__getitem__.call_args_list
         == [[(cpe.vendor_normalized,), {}] for cpe, cve in expected])
     assert (
-        list(list(c)
-             for c
-             in cpe_revmap.__getitem__.return_value.add.call_args_list)
+        cpe_revmap.__getitem__.return_value.add.call_args_list
         == [[(cve.id,), {}] for cpe, cve in expected])
 
 
@@ -648,21 +642,21 @@ async def test_checker_parse_cve_response(patches, raises):
                 is None)
 
     assert (
-        list(download.read.call_args)
+        download.read.call_args
         == [(), {}])
     if raises == aiohttp.client_exceptions.ClientPayloadError:
         assert not m_gzip.called
         assert not m_json.loads.called
         return
     assert (
-        list(m_gzip.call_args)
+        m_gzip.call_args
         == [(download.read.return_value, ), {}])
     if raises == gzip.BadGzipFile:
         assert not m_json.loads.called
         return
     assert (
-        list(m_json.loads.call_args)
+        m_json.loads.call_args
         == [(m_gzip.return_value, ), {}])
     assert (
-        list(m_parse.call_args)
+        m_parse.call_args
         == [(m_json.loads.return_value, cves, cpe_revmap), {}])

--- a/envoy.dependency.cve_scan/tests/test_cve.py
+++ b/envoy.dependency.cve_scan/tests/test_cve.py
@@ -64,7 +64,7 @@ def test_cve_cpes(patches):
         assert cve.cpes == m_set.return_value
 
     assert (
-        list(m_gather.call_args)
+        m_gather.call_args
         == [(m_nodes.return_value, m_set.return_value), {}])
     assert "cpes" in cve.__dict__
 
@@ -80,7 +80,7 @@ def test_cve_fail_template(patches):
         assert cve.fail_template == m_jinja.Template.return_value
 
     assert (
-        list(m_jinja.Template.call_args)
+        m_jinja.Template.call_args
         == [(m_tpl.return_value, ), {}])
     assert "fail_template" in cve.__dict__
 
@@ -112,7 +112,7 @@ def test_cve_formatted_description(patches):
             == "\n  ".join(wrapped))
 
     assert (
-        list(m_wrap.wrap.call_args)
+        m_wrap.wrap.call_args
         == [(m_description.return_value, ), {}])
     assert "formatted_description" not in cve.__dict__
 
@@ -127,29 +127,29 @@ def test_cve_description():
                         .__getitem__.return_value
                         .__getitem__.return_value))
     assert (
-        list(cve.cve_data.__getitem__.call_args)
+        cve.cve_data.__getitem__.call_args
         == [("cve", ), {}])
     assert (
-        list(cve.cve_data.__getitem__.return_value
-                         .__getitem__.call_args)
+        (cve.cve_data.__getitem__.return_value
+                     .__getitem__.call_args)
         == [("description", ), {}])
     assert (
-        list(cve.cve_data.__getitem__.return_value
-                         .__getitem__.return_value
-                         .__getitem__.call_args)
+        (cve.cve_data.__getitem__.return_value
+                     .__getitem__.return_value
+                     .__getitem__.call_args)
         == [("description_data", ), {}])
     assert (
-        list(cve.cve_data.__getitem__.return_value
-                         .__getitem__.return_value
-                         .__getitem__.return_value
-                         .__getitem__.call_args)
+        (cve.cve_data.__getitem__.return_value
+                     .__getitem__.return_value
+                     .__getitem__.return_value
+                     .__getitem__.call_args)
         == [(0, ), {}])
     assert (
-        list(cve.cve_data.__getitem__.return_value
-                         .__getitem__.return_value
-                         .__getitem__.return_value
-                         .__getitem__.return_value
-                         .__getitem__.call_args)
+        (cve.cve_data.__getitem__.return_value
+                     .__getitem__.return_value
+                     .__getitem__.return_value
+                     .__getitem__.return_value
+                     .__getitem__.call_args)
         == [("value", ), {}])
     assert "description" not in cve.__dict__
 
@@ -162,16 +162,16 @@ def test_cve_id():
                         .__getitem__.return_value
                         .__getitem__.return_value))
     assert (
-        list(cve.cve_data.__getitem__.call_args)
+        cve.cve_data.__getitem__.call_args
         == [("cve", ), {}])
     assert (
-        list(cve.cve_data.__getitem__.return_value
-                         .__getitem__.call_args)
+        (cve.cve_data.__getitem__.return_value
+                     .__getitem__.call_args)
         == [("CVE_data_meta", ), {}])
     assert (
-        list(cve.cve_data.__getitem__.return_value
-                         .__getitem__.return_value
-                         .__getitem__.call_args)
+        (cve.cve_data.__getitem__.return_value
+                     .__getitem__.return_value
+                     .__getitem__.call_args)
         == [("ID", ), {}])
     assert "id" not in cve.__dict__
 
@@ -182,8 +182,8 @@ def test_cve_is_v3():
         cve.is_v3
         == (cve.cve_data.__getitem__.return_value.__contains__.return_value))
     assert (
-        list(cve.cve_data.__getitem__.return_value
-                         .__contains__.call_args)
+        (cve.cve_data.__getitem__.return_value
+                     .__contains__.call_args)
         == [("baseMetricV3", ), {}])
     assert "is_v3" not in cve.__dict__
 
@@ -197,10 +197,10 @@ def test_cve_last_modified_date(patches):
     with patched as (m_date, ):
         assert cve.last_modified_date == m_date.return_value
     assert (
-        list(m_date.call_args)
+        m_date.call_args
         == [(cve.cve_data.__getitem__.return_value, ), {}])
     assert (
-        list(cve.cve_data.__getitem__.call_args)
+        cve.cve_data.__getitem__.call_args
         == [("lastModifiedDate", ), {}])
     assert "last_modified_date" not in cve.__dict__
 
@@ -212,11 +212,11 @@ def test_cve_nodes():
         == (cve.cve_data.__getitem__.return_value
                         .__getitem__.return_value))
     assert (
-        list(cve.cve_data.__getitem__.call_args)
+        cve.cve_data.__getitem__.call_args
         == [("configurations", ), {}])
     assert (
-        list(cve.cve_data.__getitem__.return_value
-                         .__getitem__.call_args)
+        (cve.cve_data.__getitem__.return_value
+                     .__getitem__.call_args)
         == [("nodes", ), {}])
     assert "nodes" not in cve.__dict__
 
@@ -230,10 +230,10 @@ def test_cve_published_date(patches):
     with patched as (m_date, ):
         assert cve.published_date == m_date.return_value
     assert (
-        list(m_date.call_args)
+        m_date.call_args
         == [(cve.cve_data.__getitem__.return_value, ), {}])
     assert (
-        list(cve.cve_data.__getitem__.call_args)
+        cve.cve_data.__getitem__.call_args
         == [("publishedDate", ), {}])
     assert "published_date" not in cve.__dict__
 
@@ -247,22 +247,22 @@ def test_cve_score():
                         .__getitem__.return_value
                         .__getitem__.return_value))
     assert (
-        list(cve.cve_data.__getitem__.call_args)
+        cve.cve_data.__getitem__.call_args
         == [("impact", ), {}])
     assert (
-        list(cve.cve_data.__getitem__.return_value
-                         .__getitem__.call_args)
+        (cve.cve_data.__getitem__.return_value
+                     .__getitem__.call_args)
         == [("baseMetricV3", ), {}])
     assert (
-        list(cve.cve_data.__getitem__.return_value
-                         .__getitem__.return_value
-                         .__getitem__.call_args)
+        (cve.cve_data.__getitem__.return_value
+                     .__getitem__.return_value
+                     .__getitem__.call_args)
         == [("cvssV3", ), {}])
     assert (
-        list(cve.cve_data.__getitem__.return_value
-                         .__getitem__.return_value
-                         .__getitem__.return_value
-                         .__getitem__.call_args)
+        (cve.cve_data.__getitem__.return_value
+                     .__getitem__.return_value
+                     .__getitem__.return_value
+                     .__getitem__.call_args)
         == [("baseScore", ), {}])
     assert "score" not in cve.__dict__
 
@@ -276,22 +276,22 @@ def test_cve_severity():
                         .__getitem__.return_value
                         .__getitem__.return_value))
     assert (
-        list(cve.cve_data.__getitem__.call_args)
+        cve.cve_data.__getitem__.call_args
         == [("impact", ), {}])
     assert (
-        list(cve.cve_data.__getitem__.return_value
-                         .__getitem__.call_args)
+        (cve.cve_data.__getitem__.return_value
+                     .__getitem__.call_args)
         == [("baseMetricV3", ), {}])
     assert (
-        list(cve.cve_data.__getitem__.return_value
-                         .__getitem__.return_value
-                         .__getitem__.call_args)
+        (cve.cve_data.__getitem__.return_value
+                     .__getitem__.return_value
+                     .__getitem__.call_args)
         == [("cvssV3", ), {}])
     assert (
-        list(cve.cve_data.__getitem__.return_value
-                         .__getitem__.return_value
-                         .__getitem__.return_value
-                         .__getitem__.call_args)
+        (cve.cve_data.__getitem__.return_value
+                     .__getitem__.return_value
+                     .__getitem__.return_value
+                     .__getitem__.call_args)
         == [("baseSeverity", ), {}])
     assert "severity" not in cve.__dict__
 
@@ -338,7 +338,7 @@ def test_cve_dependency_match(patches, matches):
 
     if expected and expected[-1] == "*":
         assert (
-            list(list(c) for c in m_match.call_args_list)
+            m_match.call_args_list
             == [[(dep, ), {}]])
     else:
         assert not m_match.called
@@ -353,7 +353,7 @@ def test_cve_dependency_match(patches, matches):
                 previous_result = True
         if not previous_result:
             assert (
-                list(cpe.dependency_match.call_args)
+                cpe.dependency_match.call_args
                 == [(dep,), {}])
         else:
             assert not cpe.dependency_match.called
@@ -372,7 +372,7 @@ def test_cve_format_failure(patches):
             == m_template.return_value.render.return_value)
 
     assert (
-        list(m_template.return_value.render.call_args)
+        m_template.return_value.render.call_args
         == [(), {'cve': cve, 'dependency': dependency}])
 
 
@@ -430,7 +430,7 @@ def test_cve_gather_cpes(patches, include):
         assert not cve.gather_cpes(nodes, cpe_set)
 
     assert (
-        list(list(c) for c in m_class.return_value.from_string.call_args_list)
+        m_class.return_value.from_string.call_args_list
         == [[('URI0',), {}],
             [('URI1',), {}], [('URI2',), {}],
             [('URI3',), {}], [('URI4',), {}],
@@ -439,7 +439,7 @@ def test_cve_gather_cpes(patches, include):
             [('URIab5',), {}], [('URIab6',), {}]])
     cpe_obj = m_class.return_value.from_string.return_value
     assert (
-        list(list(c) for c in m_include.call_args_list)
+        m_include.call_args_list
         == [[({'data': 'DATA0'}, cpe_obj), {}],
             [({'data': 'DATA1'}, cpe_obj), {}],
             [({'data': 'DATA2'}, cpe_obj), {}],
@@ -456,7 +456,7 @@ def test_cve_gather_cpes(patches, include):
         if include == "odd"
         else 5)
     assert (
-        list(list(c) for c in cpe_set.add.call_args_list)
+        cpe_set.add.call_args_list
         == [[(cpe_obj,), {}]] * expected_cpe_count)
 
 
@@ -480,19 +480,19 @@ def test_cve_include_version(patches, tracked, matches):
             == (tracked and matches))
 
     assert (
-        list(tracked_cpes.__contains__.call_args)
+        tracked_cpes.__contains__.call_args
         == [(str(cpe),), {}])
     if not tracked:
         assert not m_matcher.called
         return
     assert (
-        list(m_matcher.return_value.call_args)
+        m_matcher.return_value.call_args
         == [(cpe_match,), {}])
     assert (
-        list(m_matcher.return_value.return_value.call_args)
+        m_matcher.return_value.return_value.call_args
         == [(tracked_cpes.__getitem__.return_value,), {}])
     assert (
-        list(tracked_cpes.__getitem__.call_args)
+        tracked_cpes.__getitem__.call_args
         == [(str(cpe),), {}])
 
 
@@ -519,13 +519,13 @@ def test_cve_parse_cve_date(patches, is_utc):
             == m_date.fromisoformat.return_value)
 
     assert (
-        list(m_date.fromisoformat.call_args)
+        m_date.fromisoformat.call_args
         == [(date_str.split.return_value.__getitem__.return_value,), {}])
     assert (
-        list(date_str.split.call_args)
+        date_str.split.call_args
         == [("T", ), {}])
     assert (
-        list(date_str.split.return_value.__getitem__.call_args)
+        date_str.split.return_value.__getitem__.call_args
         == [(0, ), {}])
 
 
@@ -548,5 +548,5 @@ def test_cve_wildcard_version_match(patches, release_date, published_date):
             == (release_date <= published_date))
 
     assert (
-        list(m_date.fromisoformat.call_args)
+        m_date.fromisoformat.call_args
         == [(dep.release_date, ), {}])

--- a/envoy.dependency.cve_scan/tests/test_dependency.py
+++ b/envoy.dependency.cve_scan/tests/test_dependency.py
@@ -60,7 +60,7 @@ def test_dependency_release_version(patches, raises):
                 == (m_version.return_value if not raises else None))
 
     assert (
-        list(m_version.call_args)
+        m_version.call_args
         == [(m_dep_version.return_value, ), {}])
     if raises != Exception:
         assert "release_version" in dependency.__dict__

--- a/envoy.dependency.cve_scan/tests/test_version_matcher.py
+++ b/envoy.dependency.cve_scan/tests/test_version_matcher.py
@@ -93,15 +93,15 @@ def test_matcher__cpe_version(patches, version_info):
                 else None))
 
     assert (
-        list(cpe_match.get.call_args)
+        cpe_match.get.call_args
         == [("versionActionEndingluding", None), {}])
     if version_info is None:
         assert not m_version.Version.called
         assert not m_utils.typed.called
         return
     assert (
-        list(m_version.Version.call_args)
+        m_version.Version.call_args
         == [(m_utils.typed.return_value, ), {}])
     assert (
-        list(m_utils.typed.call_args)
+        m_utils.typed.call_args
         == [(str, cpe_match.get.return_value), {}])

--- a/envoy.dependency.pip_check/tests/test_abstract.py
+++ b/envoy.dependency.pip_check/tests/test_abstract.py
@@ -40,7 +40,7 @@ def test_abstract_pip_checker_config_requirements():
             {"package-ecosystem": "pip", "directory": "dir3"}]
         assert checker.config_requirements == {'dir1', 'dir3'}
         assert (
-            list(m_config.return_value.__getitem__.call_args)
+            m_config.return_value.__getitem__.call_args
             == [('updates',), {}])
 
 
@@ -68,10 +68,10 @@ def test_abstract_pip_checker_dependabot_config(patches, isdict):
                     f"{checker.dependabot_config_path}"))
 
     assert (
-        list(m_path.return_value.joinpath.call_args)
+        m_path.return_value.joinpath.call_args
         == [(checker._dependabot_config, ), {}])
     assert (
-        list(m_utils.from_yaml.call_args)
+        m_utils.from_yaml.call_args
         == [(m_path.return_value.joinpath.return_value,), {}])
 
 
@@ -139,7 +139,7 @@ def test_abstract_pip_checker_requirements_dirs(patches, matches):
 
     for exp in expected:
         assert (
-            list(exp.parent.relative_to.call_args)
+            exp.parent.relative_to.call_args
             == [(m_path.return_value,), {}])
     assert "requirements_dirs" in checker.__dict__
 
@@ -172,7 +172,7 @@ async def test_abstract_pip_checker_check_dependabot(patches, requirements):
 
     if config & dirs:
         assert (
-            list(m_success.call_args)
+            m_success.call_args
             == [(config & dirs, ), {}])
     else:
         assert not m_success.called
@@ -182,14 +182,14 @@ async def test_abstract_pip_checker_check_dependabot(patches, requirements):
               (f"Missing {m_fname.return_value} dir, "
                "specified in dependabot config")),
              {}]
-            in list(list(c) for c in m_errors.call_args_list))
+            in list(m_errors.call_args_list))
 
     if dirs - config:
         assert (
             [(dirs - config,
               f"Missing dependabot config for {m_fname.return_value} in dir"),
              {}]
-            in list(list(c) for c in m_errors.call_args_list))
+            in list(m_errors.call_args_list))
 
     if not config - dirs and not dirs - config:
         assert not m_errors.called
@@ -208,7 +208,7 @@ def test_abstract_pip_checker_dependabot_success(patches):
         checker.dependabot_success(success)
 
     assert (
-        list(m_succeed.call_args)
+        m_succeed.call_args
         == [('dependabot',
              [f"{m_fname.return_value}: {x}" for x in sorted(success)]),  {}])
 
@@ -227,7 +227,7 @@ def test_abstract_pip_checker_dependabot_errors(patches):
         checker.dependabot_errors(errors, msg)
 
     assert (
-        list(list(c) for c in list(m_error.call_args_list))
+        m_error.call_args_list
         == [[('dependabot', [f'ERROR MESSAGE: {x}']), {}]
             for x in sorted(errors)])
 

--- a/envoy.distribution.distrotest/tests/test_distrotest.py
+++ b/envoy.distribution.distrotest/tests/test_distrotest.py
@@ -50,7 +50,7 @@ def test_config_dunder_getitem(patches):
             == m_config.return_value.__getitem__.return_value)
 
     assert (
-        list(m_config.return_value.__getitem__.call_args)
+        m_config.return_value.__getitem__.call_args
         == [('X',), {}])
 
 
@@ -77,7 +77,7 @@ def test_config_config(patches, isdict):
                 config.config
 
     assert (
-        list(m_utils.from_yaml.call_args)
+        m_utils.from_yaml.call_args
         == [(m_path.return_value,), {}])
     if isdict:
         assert "config" in config.__dict__
@@ -109,7 +109,7 @@ def test_config_ctx_dockerfile():
 
     assert config.ctx_dockerfile == path.joinpath.return_value
     assert (
-        list(path.joinpath.call_args)
+        path.joinpath.call_args
         == [('Dockerfile', ), {}])
     assert "ctx_dockerfile" in config.__dict__
 
@@ -127,7 +127,7 @@ def test_config_ctx_keyfile(patches):
         assert config.ctx_keyfile == path.joinpath.return_value
 
     assert (
-        list(path.joinpath.call_args)
+        path.joinpath.call_args
         == [(m_key.return_value.name, ), {}])
     assert "ctx_keyfile" in config.__dict__
 
@@ -140,7 +140,7 @@ def test_config_rel_ctx_packages():
 
     assert config.rel_ctx_packages == path.joinpath.return_value
     assert (
-        list(path.joinpath.call_args)
+        path.joinpath.call_args
         == [(config.packages_name, ), {}])
     assert "rel_ctx_packages" in config.__dict__
 
@@ -155,7 +155,7 @@ def test_config_ctx_testfile():
     assert config.ctx_testfile == path.joinpath.return_value
 
     assert (
-        list(path.joinpath.call_args)
+        path.joinpath.call_args
         == [(testfile.name, ), {}])
     assert "ctx_testfile" in config.__dict__
 
@@ -202,7 +202,7 @@ def test_config_install_img_path(patches):
         assert config.install_img_path == m_plib.PurePosixPath.return_value
 
     assert (
-        list(m_plib.PurePosixPath.call_args)
+        m_plib.PurePosixPath.call_args
         == [("/tmp/install",), {}])
     assert "install_img_path" in config.__dict__
 
@@ -221,7 +221,7 @@ def test_config_keyfile(patches):
         assert config.keyfile == m_key.return_value
 
     assert (
-        list(m_shutil.copyfile.call_args)
+        m_shutil.copyfile.call_args
         == [(m_sign.return_value, m_key.return_value), {}])
     assert "keyfile" in config.__dict__
 
@@ -238,7 +238,7 @@ def test_config_keyfile_img_path(patches):
         assert config.keyfile_img_path == m_plib.PurePosixPath.return_value
 
     assert (
-        list(m_plib.PurePosixPath.call_args)
+        m_plib.PurePosixPath.call_args
         == [("/tmp/gpg/signing.key",), {}])
     assert "keyfile_img_path" in config.__dict__
 
@@ -256,7 +256,7 @@ def test_config_packages_dir(patches):
         assert config.packages_dir == m_packages.return_value
 
     assert (
-        list(m_utils.extract.call_args)
+        m_utils.extract.call_args
         == [(m_packages.return_value, "TARBALL"), {}])
     assert "packages_dir" in config.__dict__
 
@@ -278,7 +278,7 @@ def test_config_signing_key(patches):
             == m_packages.return_value.joinpath.return_value)
 
     assert (
-        list(m_packages.return_value.joinpath.call_args)
+        m_packages.return_value.joinpath.call_args
         == [(m_keypath.return_value, ), {}])
     assert "signing_key" in config.__dict__
 
@@ -296,7 +296,7 @@ def test_config_testfile(patches):
         assert config.testfile == m_key.return_value
 
     assert (
-        list(m_shutil.copyfile.call_args)
+        m_shutil.copyfile.call_args
         == [("TESTFILE", m_key.return_value), {}])
     assert "testfile" in config.__dict__
 
@@ -316,10 +316,10 @@ def test_config_testfile_img_path(patches):
             == m_plib.PurePosixPath.return_value.joinpath.return_value)
 
     assert (
-        list(m_plib.PurePosixPath.call_args)
+        m_plib.PurePosixPath.call_args
         == [("/tmp",), {}])
     assert (
-        list(m_plib.PurePosixPath.return_value.joinpath.call_args)
+        m_plib.PurePosixPath.return_value.joinpath.call_args
         == [(m_name.return_value.name,), {}])
     assert "testfile_img_path" in config.__dict__
 
@@ -341,10 +341,10 @@ def test_config_get_config(patches):
             == m_images.return_value.__getitem__.return_value)
 
     assert (
-        list(m_images.return_value.__getitem__.call_args)
+        m_images.return_value.__getitem__.call_args
         == [(m_name.return_value, ), {}])
     assert (
-        list(m_name.call_args)
+        m_name.call_args
         == [("IMAGE", ), {}])
 
 
@@ -357,10 +357,10 @@ def test_config_get_image_name():
         config.get_image_name(image)
         == image.split.return_value.__getitem__.return_value)
     assert (
-        list(image.split.call_args)
+        image.split.call_args
         == [(":", ), {}])
     assert (
-        list(image.split.return_value.__getitem__.call_args)
+        image.split.return_value.__getitem__.call_args
         == [(0, ), {}])
 
 
@@ -393,10 +393,10 @@ def test_config_get_package_type(patches, pkg_type, pkg_types):
             assert e.value.args[0] == f"Unrecognized image: {pkg_type}"
 
     assert (
-        list(m_name.call_args)
+        m_name.call_args
         == [("IMAGE", ), {}])
     assert (
-        list(m_items.call_args)
+        m_items.call_args
         == [(), {}])
 
 
@@ -416,10 +416,10 @@ def test_config_get_packages(patches, pkg_type, ext, packages):
         assert config.get_packages(pkg_type, ext) == packages
 
     assert (
-        list(m_pkg.return_value.joinpath.call_args)
+        m_pkg.return_value.joinpath.call_args
         == [(pkg_type,), {}])
     assert (
-        list(m_pkg.return_value.joinpath.return_value.glob.call_args)
+        m_pkg.return_value.joinpath.return_value.glob.call_args
         == [(f'*.{ext}',), {}])
 
 
@@ -435,7 +435,7 @@ def test_config_items(patches):
         assert config.items() == m_config.return_value.items.return_value
 
     assert (
-        list(m_config.return_value.items.call_args)
+        m_config.return_value.items.call_args
         == [(), {}])
 
 
@@ -499,16 +499,16 @@ def test_image_build_command(patches):
             == strip.return_value.replace.return_value)
 
     assert (
-        list(m_config.return_value.__getitem__.call_args)
+        m_config.return_value.__getitem__.call_args
         == [('build',), {}])
     assert (
-        list(config_item.call_args)
+        config_item.call_args
         == [('command',), {}])
     assert (
-        list(strip.call_args)
+        strip.call_args
         == [(), {}])
     assert (
-        list(strip.return_value.replace.call_args)
+        strip.return_value.replace.call_args
         == [("\n", " && "), {}])
     assert "build_command" not in image.__dict__
 
@@ -524,7 +524,7 @@ def test_image_config(patches):
         assert image.config == config.__getitem__.return_value
 
     assert (
-        list(config.__getitem__.call_args)
+        config.__getitem__.call_args
         == [(m_type.return_value,), {}])
     assert "config" in image.__dict__
 
@@ -543,10 +543,10 @@ def test_image_ctx_install_dir(patches):
             == m_plib.Path.return_value.joinpath.return_value)
 
     assert (
-        list(m_plib.Path.call_args)
+        m_plib.Path.call_args
         == [(m_name.return_value, ), {}])
     assert (
-        list(m_plib.Path.return_value.joinpath.call_args)
+        m_plib.Path.return_value.joinpath.call_args
         == [(m_type.return_value, ), {}])
     assert "ctx_install_dir" not in image.__dict__
 
@@ -580,7 +580,7 @@ def test_image_dockerfile(patches):
         assert image.dockerfile == m_template.return_value.format.return_value
 
     assert (
-        list(m_template.return_value.format.call_args)
+        m_template.return_value.format.call_args
         == [(),
             {'build_image': 'BUILD_IMAGE',
              'install_dir': m_install.return_value,
@@ -608,10 +608,10 @@ def test_image_env(patches, env):
             assert image.env == ""
 
     assert (
-        list(m_config.return_value.__getitem__.call_args)
+        m_config.return_value.__getitem__.call_args
         == [("build", ), {}])
     assert (
-        list(m_config.return_value.__getitem__.return_value.get.call_args)
+        m_config.return_value.__getitem__.return_value.get.call_args
         == [("env", ""), {}])
     assert "env" not in image.__dict__
 
@@ -621,7 +621,7 @@ def test_image_keyfile_package_type():
     image = distrotest.DistroTestImage(config, "BUILD_IMAGE", "NAME")
     assert image.package_type == config.get_package_type.return_value
     assert (
-        list(config.get_package_type.call_args)
+        config.get_package_type.call_args
         == [("BUILD_IMAGE", ), {}])
     assert "package_type" in image.__dict__
 
@@ -654,10 +654,10 @@ def test_image_add_dockerfile(patches):
     with patched as (m_shutil, m_dfile, m_ctx_docker):
         assert not image.add_dockerfile()
     assert (
-        list(stream.call_args)
+        stream.call_args
         == [(m_dfile.return_value,), {}])
     assert (
-        list(m_ctx_docker.return_value.write_text.call_args)
+        m_ctx_docker.return_value.write_text.call_args
         == [(m_dfile.return_value,), {}])
 
 
@@ -688,10 +688,10 @@ async def test_image_build(patches, raises):
             assert not await image.build()
 
     assert (
-        list(m_add.call_args)
+        m_add.call_args
         == [(), {}])
     assert (
-        list(m_build.call_args)
+        m_build.call_args
         == [(m_docker.return_value,
              m_path.return_value,
              m_tag.return_value),
@@ -752,7 +752,7 @@ def test_image_get_environment(patches, items):
             == _dict)
 
     assert (
-        list(m_dict.call_args)
+        m_dict.call_args
         == [(),
             {'ENVOY_MAINTAINER': config.maintainer,
              'ENVOY_VERSION': config.version,
@@ -761,29 +761,29 @@ def test_image_get_environment(patches, items):
              'PACKAGE': 'PKG_NAME',
              'DISTRO': 'DISTRO_NAME'}])
     assert (
-        list(list(c) for c in m_path.call_args_list)
+        m_path.call_args_list
         == [[(m_get.return_value,), {}],
             [('PKG_FNAME',), {}]])
     assert (
-        list(m_get.call_args)
+        m_get.call_args
         == [('PKG_FNAME',), {}])
     assert (
-        list(m_config.return_value.__getitem__.call_args)
+        m_config.return_value.__getitem__.call_args
         == [('test',), {}])
     assert (
-        list(m_config.return_value.__getitem__.return_value.items.call_args)
+        m_config.return_value.__getitem__.return_value.items.call_args
         == [(), {}])
     assert (
-        list(list(c) for c in _dict.__setitem__.call_args_list)
+        _dict.__setitem__.call_args_list
         == [[(m_k.upper.return_value, m_v.format.return_value), {}]
             for m_k, m_v in _items])
 
     for m_k, m_v in _items:
         assert (
-            list(m_k.upper.call_args)
+            m_k.upper.call_args
             == [(), {}])
         assert (
-            list(m_v.format.call_args)
+            m_v.format.call_args
             == [(), {'A': 'B'}])
 
 
@@ -811,13 +811,13 @@ def test_image_get_install_binary(patches, contains):
 
     config_item = m_config.return_value.__getitem__.return_value.__getitem__
     assert (
-        list(list(c) for c in m_config.return_value.__getitem__.call_args_list)
+        m_config.return_value.__getitem__.call_args_list
         == [[('binary_name',), {}], [('binary_name',), {}]])
     assert (
-        list(list(c) for c in config_item.call_args_list)
+        config_item.call_args_list
         == [[('match',), {}], [('replace',), {}]])
     assert (
-        list(m_re.sub.call_args)
+        m_re.sub.call_args
         == [(config_item.return_value,
              config_item.return_value,
              'PACKAGE'), {}])
@@ -842,7 +842,7 @@ async def test_image_images(patches, images):
 
     expected = [image["RepoTags"] for image in images]
     assert (
-        list(m_chain.from_iterable.call_args)
+        m_chain.from_iterable.call_args
         == [(expected,), {}])
 
 
@@ -859,7 +859,7 @@ def test_image_installable_img_path(patches):
             == m_dir.return_value.joinpath.return_value)
 
     assert (
-        list(m_dir.return_value.joinpath.call_args)
+        m_dir.return_value.joinpath.call_args
         == [("INSTALLABLE",), {}])
 
 
@@ -871,7 +871,7 @@ def test_image_stream(patches, stream):
     assert not image.stream("MESSAGE")
     if stream:
         assert (
-            list(stream.call_args)
+            stream.call_args
             == [("MESSAGE", ), {}])
 
 
@@ -962,7 +962,7 @@ def test_distrotest_environment(patches):
             == m_image.return_value.get_environment.return_value)
 
     assert (
-        list(m_image.return_value.get_environment.call_args)
+        m_image.return_value.get_environment.call_args
         == [(installable.name, m_name.return_value, 'NAME'), {}])
 
 
@@ -995,7 +995,7 @@ def test_distrotest_image(patches):
         assert dtest.image == m_class.return_value
 
     assert (
-        list(m_class.call_args)
+        m_class.call_args
         == [('CONFIG',
              'IMAGE',
              'NAME'),
@@ -1025,10 +1025,10 @@ def test_distrotest_package_name(patches):
         dtest.package_name
         == installable.name.split.return_value.__getitem__.return_value)
     assert (
-        list(installable.name.split.call_args)
+        installable.name.split.call_args
         == [('_',), {}])
     assert (
-        list(installable.name.split.return_value.__getitem__.call_args)
+        installable.name.split.return_value.__getitem__.call_args
         == [(0,), {}])
 
 
@@ -1058,7 +1058,7 @@ async def test_distrotest_build(patches, exists):
         assert not await dtest.build()
 
     assert (
-        list(m_image.return_value.exists.call_args)
+        m_image.return_value.exists.call_args
         == [(), {}])
 
     if exists:
@@ -1067,10 +1067,10 @@ async def test_distrotest_build(patches, exists):
         return
 
     assert (
-        list(m_image.return_value.build.call_args)
+        m_image.return_value.build.call_args
         == [(), {}])
     assert (
-        list(list(c) for c in m_run.call_args_list)
+        m_run.call_args_list
         == [[('Building image',), {'msg_type': 'notice'}],
             [('Image built',), {}]])
 
@@ -1095,10 +1095,10 @@ async def test_distrotest_cleanup(patches, raises):
         assert not await dtest.cleanup()
 
     assert (
-        list(m_docker.containers.get.call_args)
+        m_docker.containers.get.call_args
         == [(m_name.return_value,), {}])
     assert (
-        list(m_stop.call_args)
+        m_stop.call_args
         == [(m_docker.containers.get.return_value,), {}])
 
 
@@ -1118,7 +1118,7 @@ async def test_distrotest_create(patches):
             == m_docker.containers.create_or_replace.return_value)
 
     assert (
-        list(m_docker.containers.create_or_replace.call_args)
+        m_docker.containers.create_or_replace.call_args
         == [(),
             {'config': m_config.return_value,
              'name': m_name.return_value}])
@@ -1168,14 +1168,14 @@ async def test_distrotest_exec(patches, failed, returns, msgs):
         assert not await dtest.exec(container)
 
     assert (
-        list(container.exec.call_args)
+        container.exec.call_args
         == [(m_cmd.return_value,),
             {'environment': m_env.return_value}])
     assert (
-        list(_tracker.stream.call_args)
+        _tracker.stream.call_args
         == [(), {'detach': False}])
     assert (
-        list(container.exec.return_value.inspect.call_args)
+        container.exec.return_value.inspect.call_args
         == [(), {}])
 
     assert _tracker.counter == msgs + 1
@@ -1183,10 +1183,10 @@ async def test_distrotest_exec(patches, failed, returns, msgs):
 
     for _out in _tracker._outs:
         assert (
-            list(_out.data.decode.call_args)
+            _out.data.decode.call_args
             == [('utf-8',), {}])
         assert (
-            list(_out.data.decode.return_value.strip.call_args)
+            _out.data.decode.return_value.strip.call_args
             == [(), {}])
 
     _log_error = (msgs > 0) and (returns and not failed)
@@ -1195,18 +1195,18 @@ async def test_distrotest_exec(patches, failed, returns, msgs):
         assert dtest._failures == ['container-start']
         output = _tracker._outs[-1].data.decode.return_value.strip.return_value
         assert (
-            list(m_error.call_args)
+            m_error.call_args
             == [([(f"[NAME] Error executing test in container\n"
                    f"{output}")],), {}])
         assert (
-            list(list(c) for c in m_out.call_args_list)
+            m_out.call_args_list
             == [[(_out.data.decode.return_value.strip.return_value,), {}]
                 for _out in _tracker._outs[:-1]])
     else:
         assert dtest._failures == []
         assert not m_error.called
         assert (
-            list(list(c) for c in m_out.call_args_list)
+            m_out.call_args_list
             == [[(_out.data.decode.return_value.strip.return_value,), {}]
                 for _out in _tracker._outs])
 
@@ -1217,7 +1217,7 @@ def test_distrotest_error():
         check, "CONFIG", "NAME", "IMAGE", "INSTALLABLE")
     assert dtest.error(["ERR1", "ERR2"]) == check.error.return_value
     assert (
-        list(check.error.call_args)
+        check.error.call_args
         == [(check.active_check, ['ERR1', 'ERR2']), {}])
 
 
@@ -1248,27 +1248,27 @@ def test_distrotest_handle_test_error(patches, msg):
         assert not dtest.handle_test_error(_msg)
 
     assert (
-        list(list(c) for c in _msg.split.call_args_list)
+        _msg.split.call_args_list
         == [[(']',), {}], [('\n', 1), {}]])
     assert (
-        list(_splitter.__getitem__.call_args)
+        _splitter.__getitem__.call_args
         == [(0,), {}])
     strip = _splitter.__getitem__.return_value.strip
     assert (
-        list(strip.call_args)
+        strip.call_args
         == [('[',), {}])
     assert (
-        list(strip.return_value.split.call_args)
+        strip.return_value.split.call_args
         == [(':',), {}])
 
     assert dtest._failures == ['TESTNAME']
     assert (
-        list(m_error.call_args)
+        m_error.call_args
         == [(['[TESTRUN:TESTNAME] Test failed'],), {}])
 
     if len(msg.split("\n")) > 1:
         assert (
-            list(m_stdout.return_value.error.call_args)
+            m_stdout.return_value.error.call_args
             == [(msg.split("\n", 1)[1],), {}])
         return
 
@@ -1310,13 +1310,13 @@ async def test_distrotest_handle_test_output(patches, start, msg):
     if not _msg.startswith("[NAME") and "\n" in _msg:
         _parts = _msg.split("\n", 1)
         assert (
-            list(m_stdout.return_value.info.call_args_list[0])
+            m_stdout.return_value.info.call_args_list[0]
             == [(_parts[0],), {}])
         _msg = _parts[1]
 
     if not start.startswith("[NAME"):
         assert (
-            list(m_stdout.return_value.info.call_args)
+            m_stdout.return_value.info.call_args
             == [(_msg,), {}])
         assert not m_error.called
         assert not m_log.called
@@ -1326,14 +1326,14 @@ async def test_distrotest_handle_test_output(patches, start, msg):
 
     if "ERROR" not in msg:
         assert (
-            list(m_log.return_value.info.call_args)
+            m_log.return_value.info.call_args
             == [(_msg,), {}])
         assert not m_error.called
         return
 
     assert not m_log.called
     assert (
-        list(m_error.call_args)
+        m_error.call_args
         == [(_msg,), {}])
 
 
@@ -1360,7 +1360,7 @@ def test_distrotest_log_failures(patches, failed, failures):
         return
 
     assert (
-        list(m_log.call_args)
+        m_log.call_args
         == [(f'Package test had failures: {",".join(failures)}',),
             {'msg_type': 'error', 'test': m_name.return_value}])
 
@@ -1374,7 +1374,7 @@ async def test_distrotest_logs():
     container.log.return_value = _logs
     assert await dtest.logs(container) == "".join(_logs)
     assert (
-        list(container.log.call_args)
+        container.log.call_args
         == [(), {'stdout': True, 'stderr': True}])
 
 
@@ -1397,10 +1397,10 @@ async def test_distrotest_on_test_complete(patches, failed, self_failed):
         assert not await dtest.on_test_complete("CONTAINER", failed)
 
     assert (
-        list(m_log.call_args)
+        m_log.call_args
         == [(), {}])
     assert (
-        list(m_stop.call_args)
+        m_stop.call_args
         == [('CONTAINER',), {}])
 
     if failed or self_failed:
@@ -1409,11 +1409,11 @@ async def test_distrotest_on_test_complete(patches, failed, self_failed):
         return
 
     assert (
-        list(m_msg.call_args)
+        m_msg.call_args
         == [('Package test passed',),
             {'test': m_name.return_value}])
     assert (
-        list(check.succeed.call_args)
+        check.succeed.call_args
         == [(check.active_check, [m_msg.return_value]), {}])
 
 
@@ -1430,10 +1430,10 @@ async def test_distrotest_run(patches):
         assert not await dtest.run()
 
     assert (
-        list(m_run.call_args)
+        m_run.call_args
         == [(), {}])
     assert (
-        list(m_error.call_args)
+        m_error.call_args
         == [(m_run.return_value,), {}])
 
 
@@ -1459,13 +1459,13 @@ def test_distrotest_run_log(patches, msg_type, testname):
         assert not dtest.run_log(*args, **kwargs)
 
     assert (
-        list(m_get.call_args)
+        m_get.call_args
         == [(m_log.return_value, msg_type or 'info'), {}])
     assert (
-        list(m_get.return_value.call_args)
+        m_get.return_value.call_args
         == [(m_msg.return_value,), {}])
     assert (
-        list(m_msg.call_args)
+        m_msg.call_args
         == [('MESSAGE',), {'test': testname}])
 
 
@@ -1509,28 +1509,28 @@ async def test_distrotest_start(patches, running):
             assert e.value.args[0] == m_msg.return_value
 
     assert (
-        list(m_create.call_args)
+        m_create.call_args
         == [(), {}])
     assert (
-        list(m_create.return_value.start.call_args)
+        m_create.return_value.start.call_args
         == [(), {}])
     assert (
-        list(m_create.return_value.show.call_args)
+        m_create.return_value.show.call_args
         == [(), {}])
 
     if not running:
         assert not m_log.called
         assert (
-            list(m_msg.call_args)
+            m_msg.call_args
             == [(f"Container unable to start\n{m_logs.return_value}",),
                 {'test': m_name.return_value}])
         assert (
-            list(m_logs.call_args)
+            m_logs.call_args
             == [(m_create.return_value,), {}])
         return
 
     assert (
-        list(m_log.call_args)
+        m_log.call_args
         == [('Container started',),
             {'test': m_name.return_value}])
     assert not m_msg.called
@@ -1558,13 +1558,13 @@ async def test_distrotest_stop(patches, container):
         return
 
     assert (
-        list(container.kill.call_args)
+        container.kill.call_args
         == [(), {}])
     assert (
-        list(container.delete.call_args)
+        container.delete.call_args
         == [(), {}])
     assert (
-        list(m_log.call_args)
+        m_log.call_args
         == [('Container stopped',), {'test': m_pkg.return_value}])
 
 
@@ -1638,20 +1638,20 @@ async def test_distrotest__run(
             result = await dtest._run()
 
     assert (
-        list(m_build.call_args)
+        m_build.call_args
         == [(), {}])
 
     if build_raises or start_raises:
         assert (
-            list(m_stop.call_args)
+            m_stop.call_args
             == [(None, True), {}])
     elif exec_raises:
         assert (
-            list(m_stop.call_args)
+            m_stop.call_args
             == [(m_start.return_value, True), {}])
     else:
         assert (
-            list(m_stop.call_args)
+            m_stop.call_args
             == [(m_start.return_value, False), {}])
 
     if build_raises:
@@ -1662,7 +1662,7 @@ async def test_distrotest__run(
         return
 
     assert (
-        list(m_start.call_args)
+        m_start.call_args
         == [(), {}])
 
     if start_raises:
@@ -1672,7 +1672,7 @@ async def test_distrotest__run(
         return
 
     assert (
-        list(m_exec.call_args)
+        m_exec.call_args
         == [(m_start.return_value,), {}])
 
     if exec_raises or stop_raises:

--- a/envoy.distribution.release/tests/test_commands.py
+++ b/envoy.distribution.release/tests/test_commands.py
@@ -34,12 +34,12 @@ async def test_release_command_assets(patches, assets):
 
     if not assets:
         assert (
-            list(m_runner.return_value.log.warning.call_args)
+            m_runner.return_value.log.warning.call_args
             == [(f"Version {m_version.return_value} has no assets", ), {}])
         assert not m_runner.return_value.stdout.called
         return
     assert (
-        list(list(c) for c in m_runner.return_value.stdout.info.call_args_list)
+        m_runner.return_value.stdout.info.call_args_list
         == [[(asset["name"],), {}] for asset in assets])
 
 
@@ -54,10 +54,10 @@ def test_release_command_create_add_arguments(patches):
         assert not command.add_arguments(parser)
 
     assert (
-        list(m_super.call_args)
+        m_super.call_args
         == [(parser, ), {}])
     assert (
-        list(list(c) for c in parser.add_argument.call_args_list)
+        parser.add_argument.call_args_list
         == [[('--assets',),
              {'nargs': '*',
               'help': (
@@ -84,10 +84,10 @@ async def test_release_command_create_run(patches):
             == m_format.return_value)
 
     assert (
-        list(mock_create.call_args)
+        mock_create.call_args
         == [(), dict(assets=m_artefacts.return_value)])
     assert (
-        list(m_format.call_args)
+        m_format.call_args
         == [(), dict(FOO="bar")])
 
 
@@ -105,7 +105,7 @@ async def test_release_command_delete(patches):
         assert await command.run() == mock_delete.return_value
 
     assert (
-        list(mock_delete.call_args)
+        mock_delete.call_args
         == [(), {}])
 
 
@@ -131,7 +131,7 @@ def test_release_command_fetch_asset_types(patches, asset_types):
                 for asset_type in asset_types or []})
 
     assert (
-        list(list(c) for c in m_re.compile.call_args_list)
+        m_re.compile.call_args_list
         == [[(asset_type.split(":", 1)[1],), {}]
             for asset_type in asset_types or []])
     assert "asset_types" not in command.__dict__
@@ -149,7 +149,7 @@ def test_release_command_fetch_path(patches):
         assert command.path == m_plib.Path.return_value
 
     assert (
-        list(m_plib.Path.call_args)
+        m_plib.Path.call_args
         == [(m_args.return_value.path, ), {}])
     assert "path" not in command.__dict__
 
@@ -239,7 +239,7 @@ def test_release_command_fetch_add_arguments(patches):
 
     assert not m_super.called
     assert (
-        list(list(c) for c in parser.add_argument.call_args_list)
+        parser.add_argument.call_args_list
         == [[('version',),
              {'nargs': '*',
               'help': (
@@ -280,7 +280,7 @@ async def test_release_command_fetch_run(patches, releases):
 
     for i, release in enumerate(releases.values()):
         assert (
-            list(release.fetch.call_args)
+            release.fetch.call_args
             == [(m_path.return_value, m_types.return_value),
                 {'append': i > 0}])
 
@@ -302,7 +302,7 @@ async def test_release_command_info(patches):
             == m_format.return_value)
 
     assert (
-        list(m_format.call_args)
+        m_format.call_args
         == [(mock_release.return_value, ), {}])
 
 
@@ -323,7 +323,7 @@ async def test_release_command_list(patches, releases):
         assert not await command.run()
 
     assert (
-        list(list(c) for c in m_runner.return_value.stdout.info.call_args_list)
+        m_runner.return_value.stdout.info.call_args_list
         == [[(release["tag_name"], ), {}]
             for release in releases])
 
@@ -339,10 +339,10 @@ def test_release_command_push_add_arguments(patches):
         assert not command.add_arguments(parser)
 
     assert (
-        list(m_super.call_args)
+        m_super.call_args
         == [(parser, ), {}])
     assert (
-        list(list(c) for c in parser.add_argument.call_args_list)
+        parser.add_argument.call_args_list
         == [[('--assets',),
              {'nargs': '*',
               'help': (
@@ -366,5 +366,5 @@ async def test_release_command_push_run(patches):
         assert not await command.run()
 
     assert (
-        list(mock_push.call_args)
+        mock_push.call_args
         == [(m_artefacts.return_value, ), {}])

--- a/envoy.distribution.release/tests/test_runner.py
+++ b/envoy.distribution.release/tests/test_runner.py
@@ -44,7 +44,7 @@ def test_runner_add_arguments(patches):
         assert not run.add_arguments("PARSER")
 
     assert (
-        list(m_args.call_args)
+        m_args.call_args
         == [("PARSER", ), {}])
 
 

--- a/envoy.distribution.repo/tests/test_abstract.py
+++ b/envoy.distribution.repo/tests/test_abstract.py
@@ -93,7 +93,7 @@ def test_repo_buildingrunner_asset_types(patches):
                 for i in range(0, 5)})
 
     assert (
-        list(list(c) for c in m_re.compile.call_args_list)
+        m_re.compile.call_args_list
         == [[(v.file_types, ), {}] for v in repo_types.values()])
     assert "asset_types" in runner.__dict__
 
@@ -112,7 +112,7 @@ def test_repo_buildingrunner_path(patches):
             == m_plib.Path.return_value)
 
     assert (
-        list(m_plib.Path.call_args)
+        m_plib.Path.call_args
         == [(m_temp.return_value.name, ), {}])
     assert "path" in runner.__dict__
 
@@ -142,7 +142,7 @@ def test_repo_buildingrunner_release_config(patches, exists, casts):
                 == m_utils.typed.return_value)
 
     assert (
-        list(m_config.return_value.exists.call_args)
+        m_config.return_value.exists.call_args
         == [(), {}])
 
     if not exists:
@@ -154,12 +154,12 @@ def test_repo_buildingrunner_release_config(patches, exists, casts):
         assert not m_utils.from_yaml.called
         return
     assert (
-        list(m_utils.typed.call_args)
+        m_utils.typed.call_args
         == [(repo.ReleaseConfigDict,
              m_utils.from_yaml.return_value),
             {}])
     assert (
-        list(m_utils.from_yaml.call_args)
+        m_utils.from_yaml.call_args
         == [(m_config.return_value, ), {}])
     if not casts:
         assert (
@@ -183,7 +183,7 @@ def test_repo_buildingrunner_releaes_config_file(patches):
             == m_plib.Path.return_value)
 
     assert (
-        list(m_plib.Path.call_args)
+        m_plib.Path.call_args
         == [(repo.abstract.PUBLISH_YAML, ), {}])
     assert "release_config_file" not in runner.__dict__
 
@@ -218,7 +218,7 @@ def test_repo_buildingrunner_repos(patches):
 
     for k, v in repo_types.items():
         assert (
-            list(v.call_args)
+            v.call_args
             == [(k,
                  m_path.return_value,
                  m_config.return_value,
@@ -244,7 +244,7 @@ async def test_repo_buildingrunner_published_repos(patches):
     assert results == [m.publish.return_value for m in repos]
     for m in repos:
         assert (
-            list(m.publish.call_args)
+            m.publish.call_args
             == [(), {}])
 
 
@@ -265,12 +265,12 @@ def test_repo_buildingrunner_add_arguments(patches):
         assert not runner.add_arguments(parser)
 
     assert (
-        list(m_super.call_args)
+        m_super.call_args
         == [(parser, ), {}])
 
     for manager in repo_types.values():
         assert (
-            list(manager.add_arguments.call_args)
+            manager.add_arguments.call_args
             == [(parser, ), {}])
 
 
@@ -284,7 +284,7 @@ async def test_repo_buildingrunner_cleanup(patches):
         assert not await runner.cleanup()
 
     assert (
-        list(m_super.call_args)
+        m_super.call_args
         == [(), {}])
 
 

--- a/envoy.distribution.repo/tests/test_deb.py
+++ b/envoy.distribution.repo/tests/test_deb.py
@@ -46,10 +46,10 @@ async def test_aaptly_aptly_config(patches):
             == m_json.loads.return_value)
 
     assert (
-        list(m_aptly.call_args)
+        m_aptly.call_args
         == [("config", "show"), {}])
     assert (
-        list(m_json.loads.call_args)
+        m_json.loads.call_args
         == [(m_aptly.return_value, ), {}])
     assert async_property.is_cached(aptly, "aptly_config")
 
@@ -72,20 +72,20 @@ async def test_aaptly_aptly_published(patches):
                 for p in parts])
 
     assert (
-        list(m_aptly.call_args)
+        m_aptly.call_args
         == [("publish", "list", "-raw"), {}])
     assert (
-        list(mock_strip.call_args)
+        mock_strip.call_args
         == [(), {}])
     assert (
-        list(mock_split.call_args)
+        mock_split.call_args
         == [("\n", ), {}])
     for part in parts:
         assert (
-            list(part.split.call_args)
+            part.split.call_args
             == [(" ", ), {}])
         assert (
-            list(part.split.return_value.__getitem__.call_args)
+            part.split.return_value.__getitem__.call_args
             == [(1, ), {}])
     assert not async_property.is_cached(aptly, "published")
 
@@ -106,10 +106,10 @@ async def test_aaptly_aptly_root_dir(patches):
             == m_plib.Path.return_value)
 
     assert (
-        list(mock_config.return_value.__getitem__.call_args)
+        mock_config.return_value.__getitem__.call_args
         == [("rootDir", ), {}])
     assert (
-        list(m_plib.Path.call_args)
+        m_plib.Path.call_args
         == [(mock_config.return_value.__getitem__.return_value, ), {}])
     assert not async_property.is_cached(aptly, "aptly_root_dir")
 
@@ -128,13 +128,13 @@ async def test_aaptly_aptly_repos(patches):
             == mock_strip.return_value.split.return_value)
 
     assert (
-        list(m_aptly.call_args)
+        m_aptly.call_args
         == [("repo", "list", "-raw"), {}])
     assert (
-        list(mock_strip.call_args)
+        mock_strip.call_args
         == [(), {}])
     assert (
-        list(mock_strip.return_value.split.call_args)
+        mock_strip.return_value.split.call_args
         == [("\n", ), {}])
     assert not async_property.is_cached(aptly, "repos")
 
@@ -153,13 +153,13 @@ async def test_aaptly_aptly_snapshots(patches):
             == mock_strip.return_value.split.return_value)
 
     assert (
-        list(m_aptly.call_args)
+        m_aptly.call_args
         == [("snapshot", "list", "-raw"), {}])
     assert (
-        list(mock_strip.call_args)
+        mock_strip.call_args
         == [(), {}])
     assert (
-        list(mock_strip.return_value.split.call_args)
+        mock_strip.return_value.split.call_args
         == [("\n", ), {}])
     assert not async_property.is_cached(aptly, "snapshots")
 
@@ -198,7 +198,7 @@ async def test_aaptly_aptly_aptly(patches, return_code, stderr, args):
                 == mock_run.return_value.stdout)
 
     assert (
-        list(m_aio.core.subprocess.run.call_args)
+        m_aio.core.subprocess.run.call_args
         == [(command, ),
             dict(capture_output=True, encoding="utf-8")])
     if return_code:
@@ -210,13 +210,13 @@ async def test_aaptly_aptly_aptly(patches, return_code, stderr, args):
         assert not m_log.called
         return
     assert (
-        list(mock_run.return_value.stderr.strip.call_args)
+        mock_run.return_value.stderr.strip.call_args
         == [(), {}])
     if not stderr:
         assert not m_log.called
         return
     assert (
-        list(m_log.return_value.info.call_args)
+        m_log.return_value.info.call_args
         == [(mock_run.return_value.stderr, ), {}])
 
 
@@ -225,7 +225,7 @@ def test_deb_repomanager_add_arguments():
     parser = MagicMock()
     assert not repo.DebRepoManager.add_arguments(parser)
     assert (
-        list(list(c) for c in parser.add_argument.call_args_list)
+        parser.add_argument.call_args_list
         == [[('--deb_aptly_command',), {'nargs': '?'}]])
 
 
@@ -247,7 +247,7 @@ def test_deb_repomanager_constructor(patches, aptly_command):
     assert manager._aptly_command == aptly_command
     assert manager.file_types == r".*(\.deb|\.changes)$"
     assert (
-        list(m_super.call_args)
+        m_super.call_args
         == [(manager, "NAME", "PATH", "CONFIG", "LOG", "STDOUT"), {}])
 
 
@@ -282,7 +282,7 @@ def test_deb_repomanager_aptly_command(patches, cmd, exists, which):
         return
 
     assert (
-        list(m_plib.Path.call_args)
+        m_plib.Path.call_args
         == [(cmd or which, ), {}])
 
     if exists:
@@ -302,7 +302,7 @@ def test_deb_repomanager_changes_files():
     path.glob.return_value = paths
     assert manager.changes_files == tuple(paths)
     assert (
-        list(path.glob.call_args)
+        path.glob.call_args
         == [(f"**/{name}/*.changes", ), {}])
     assert "changes_files" in manager.__dict__
 
@@ -321,13 +321,13 @@ def test_deb_repomanager_distros(patches):
         assert manager.distros == m_set.return_value
 
     assert (
-        list(m_set.call_args)
+        m_set.call_args
         == [(m_chain.from_iterable.return_value, ), {}])
     assert (
-        list(m_chain.from_iterable.call_args)
+        m_chain.from_iterable.call_args
         == [(m_versions.return_value.values.return_value, ), {}])
     assert (
-        list(m_versions.return_value.values.call_args)
+        m_versions.return_value.values.call_args
         == [(), {}])
 
 
@@ -350,35 +350,35 @@ async def test_deb_repomanager_create_distro(patches, exists):
         assert not await manager.create_distro("DISTRO")
 
     assert (
-        list(m_exists.call_args)
+        m_exists.call_args
         == [("DISTRO", ), {}])
     if exists:
         assert (
-            list(m_rm.call_args)
+            m_rm.call_args
             == [("DISTRO", ), {}])
     else:
         assert not m_rm.called
     assert (
-        list(m_log.return_value.notice.call_args)
+        m_log.return_value.notice.call_args
         == [("Creating deb distribution: DISTRO", ), {}])
     assert (
-        list(m_aptly.call_args)
+        m_aptly.call_args
         == [("repo", "create",
              "-distribution=\"DISTRO\"",
              "-component=main",
              "DISTRO"), {}])
     mock_split = mock_strip.return_value.split
     assert (
-        list(m_log.return_value.success.call_args)
+        m_log.return_value.success.call_args
         == [(mock_split.return_value.__getitem__.return_value, ), {}])
     assert (
-        list(mock_strip.call_args)
+        mock_strip.call_args
         == [(), {}])
     assert (
-        list(mock_split.call_args)
+        mock_split.call_args
         == [("\n", ), {}])
     assert (
-        list(mock_split.return_value.__getitem__.call_args)
+        mock_split.return_value.__getitem__.call_args
         == [(0, ), {}])
 
 
@@ -401,23 +401,23 @@ async def test_deb_repomanager_create_snapshot(patches, exists):
         assert not await manager.create_snapshot("DISTRO")
 
     assert (
-        list(m_exists.call_args)
+        m_exists.call_args
         == [("DISTRO", ), {}])
     if exists:
         assert (
-            list(m_rm.call_args)
+            m_rm.call_args
             == [("DISTRO", ), {}])
     else:
         assert not m_rm.called
     assert (
-        list(m_aptly.call_args)
+        m_aptly.call_args
         == [("snapshot", "create",
              "DISTRO", "from", "repo", "DISTRO"), {}])
     assert (
-        list(m_log.return_value.success.call_args)
+        m_log.return_value.success.call_args
         == [(mock_strip.return_value, ), {}])
     assert (
-        list(mock_strip.call_args)
+        mock_strip.call_args
         == [(), {}])
 
 
@@ -451,10 +451,10 @@ async def test_deb_repomanager_drop_distro(patches):
         assert not await manager.drop_distro("DISTRO")
 
     assert (
-        list(m_log.return_value.warning.call_args)
+        m_log.return_value.warning.call_args
         == [("Removing existing repo DISTRO", ), {}])
     assert (
-        list(m_aptly.call_args)
+        m_aptly.call_args
         == [("repo", "drop", "-force", "DISTRO"), {}])
 
 
@@ -471,10 +471,10 @@ async def test_deb_repomanager_drop_published(patches):
         assert not await manager.drop_published("DISTRO")
 
     assert (
-        list(m_log.return_value.warning.call_args)
+        m_log.return_value.warning.call_args
         == [("Removing existing published version DISTRO", ), {}])
     assert (
-        list(m_aptly.call_args)
+        m_aptly.call_args
         == [("publish", "drop", "DISTRO"), {}])
 
 
@@ -495,19 +495,19 @@ async def test_deb_repomanager_drop_snapshot(patches, exists):
         assert not await manager.drop_snapshot("DISTRO")
 
     assert (
-        list(m_log.return_value.warning.call_args)
+        m_log.return_value.warning.call_args
         == [("Removing existing snapshot DISTRO", ), {}])
     assert (
-        list(m_exists.call_args)
+        m_exists.call_args
         == [("DISTRO", ), {}])
     if exists:
         assert (
-            list(m_rm.call_args)
+            m_rm.call_args
             == [("DISTRO", ), {}])
     else:
         assert not m_rm.called
     assert (
-        list(m_aptly.call_args)
+        m_aptly.call_args
         == [("snapshot", "drop", "-force",
              "DISTRO"), {}])
 
@@ -568,20 +568,20 @@ async def test_deb_repomanager_include_changes_file(
         return
 
     assert (
-        list(m_aptly.call_args)
+        m_aptly.call_args
         == [("repo", "include", "-no-remove-files", changes_file), {}])
     assert (
-        list(mock_strip.call_args)
+        mock_strip.call_args
         == [(), {}])
     mock_split = mock_strip.return_value.split
     assert (
-        list(mock_split.call_args)
+        mock_split.call_args
         == [("\n", ), {}])
     assert (
-        list(mock_split.return_value.__getitem__.call_args)
+        mock_split.return_value.__getitem__.call_args
         == [(-1, ), {}])
     assert (
-        list(m_log.return_value.success.call_args)
+        m_log.return_value.success.call_args
         == [(mock_split.return_value.__getitem__.return_value, ), {}])
 
 
@@ -608,10 +608,10 @@ async def test_deb_repomanager_publish(patches):
             == mock_dir.return_value)
 
     assert (
-        list(m_log.return_value.notice.call_args)
+        m_log.return_value.notice.call_args
         == [("Building deb repository", ), {}])
     assert (
-        list(list(c) for c in m_publish.call_args_list)
+        m_publish.call_args_list
         == [[(distro, ), {}] for distro in distros])
 
 
@@ -634,7 +634,7 @@ async def test_deb_repomanager_publish_distro(patches):
         assert not await manager.publish_distro("DISTRO")
 
     assert (
-        list(list(c) for c in order_mock.call_args_list)
+        order_mock.call_args_list
         == [[('CREATE_DISTRO',), {}],
             [('INCLUDE',), {}],
             [('CREATE_SNAP',), {}],
@@ -658,13 +658,13 @@ async def test_deb_repomanager_publish_snapshot(patches):
         assert not await manager.publish_snapshot("DISTRO")
 
     assert (
-        list(m_aptly.call_args)
+        m_aptly.call_args
         == [("publish", "snapshot",
              "-distribution=DISTRO",
              f"-architectures={','.join(architectures)}",
              "DISTRO"), {}])
     assert (
-        list(m_log.return_value.info.call_args)
+        m_log.return_value.info.call_args
         == [(m_aptly.return_value, ), {}])
 
 

--- a/envoy.distribution.repo/tests/test_runner.py
+++ b/envoy.distribution.repo/tests/test_runner.py
@@ -31,7 +31,7 @@ def test_runner_archive(patches, archive):
         assert not m_plib.Path.called
     else:
         assert (
-            list(m_plib.Path.call_args)
+            m_plib.Path.call_args
             == [(m_args.return_value.archive, ), {}])
     assert "archive" not in runner.__dict__
 
@@ -53,7 +53,7 @@ def test_runner_packages(patches):
                      for i in range(0, 5)))
 
     assert (
-        list(m_plib.Path.call_args_list)
+        m_plib.Path.call_args_list
         == [[(package, ), {}] for package in packages])
 
     assert "packages" not in runner.__dict__
@@ -70,10 +70,10 @@ def test_runner_add_arguments(patches):
         assert not runner.add_arguments(parser)
 
     assert (
-        list(m_super.call_args)
+        m_super.call_args
         == [(parser, ), {}])
     assert (
-        list(list(c) for c in parser.add_argument.call_args_list)
+        parser.add_argument.call_args_list
         == [[('--packages',),
              {'nargs': '*'}],
             [('--archive',),
@@ -100,17 +100,17 @@ def test_runner_create_archive(patches, archive):
     if not archive:
         assert not m_tar.open.called
         assert (
-            list(m_log.return_value.warning.call_args)
+            m_log.return_value.warning.call_args
             == [("No `--archive` argument provided, dry run only", ), {}])
         return
 
     assert not m_log.called
     assert (
-        list(m_tar.open.call_args)
+        m_tar.open.call_args
         == [(m_archive.return_value, "w"), {}])
     tfile = m_tar.open.return_value.__enter__.return_value
     assert (
-        list(list(c) for c in tfile.add.call_args_list)
+        tfile.add.call_args_list
         == [[(path, ), dict(arcname=".")]
             for path in paths])
 
@@ -131,7 +131,7 @@ def test_runner_extract_packages(patches):
         assert not runner.extract_packages()
 
     assert (
-        list(list(c) for c in m_utils.extract.call_args_list)
+        m_utils.extract.call_args_list
         == [[(m_path.return_value, p), {}]
             for p in m_packages.return_value])
 
@@ -152,14 +152,14 @@ async def test_runner_run(patches):
         assert not await runner.run()
 
     assert (
-        list(m_extract.call_args)
+        m_extract.call_args
         == [(), {}])
     assert (
-        list(m_create.call_args)
+        m_create.call_args
         == [tuple(create_args), {}])
     filter = m_utils.async_list.call_args.kwargs["filter"]
     assert (
-        list(m_utils.async_list.call_args)
+        m_utils.async_list.call_args
         == [(m_repos.return_value, ), dict(filter=filter)])
     assert filter("XYZ") == "XYZ"
     assert filter(None) is None

--- a/envoy.distribution.verify/tests/test_verify.py
+++ b/envoy.distribution.verify/tests/test_verify.py
@@ -60,7 +60,7 @@ def _check_arg_path_property(patches, prop, arg=None):
         assert getattr(checker, prop) == m_plib.Path.return_value
 
     assert (
-        list(m_plib.Path.call_args)
+        m_plib.Path.call_args
         == [(getattr(m_args.return_value, arg or prop), ), {}])
     assert prop not in checker.__dict__
 
@@ -100,7 +100,7 @@ def test_checker_config(patches, is_dict):
                 checker.config
 
     assert (
-        list(m_utils.from_yaml.call_args)
+        m_utils.from_yaml.call_args
         == [(m_args.return_value.config,), {}])
 
     if is_dict:
@@ -121,7 +121,7 @@ def test_checker_docker(patches):
         assert checker.docker == m_docker.Docker.return_value
 
     assert (
-        list(m_docker.Docker.call_args)
+        m_docker.Docker.call_args
         == [(), {}])
     assert "docker" in checker.__dict__
 
@@ -156,7 +156,7 @@ def test_checker_path(patches):
         assert checker.path == m_plib.Path.return_value
 
     assert (
-        list(m_plib.Path.call_args)
+        m_plib.Path.call_args
         == [(m_temp.return_value.name, ), {}])
     assert "path" not in checker.__dict__
 
@@ -186,7 +186,7 @@ def test_checker_test_config(patches):
         assert checker.test_config == m_class.return_value.return_value
 
     assert (
-        list(m_class.return_value.call_args)
+        m_class.return_value.call_args
         == [(),
             {'docker': m_docker.return_value,
              'path': m_path.return_value,
@@ -248,18 +248,16 @@ def test_checker_tests(patches, config, distributions):
         assert result[k] == m_tconfig.return_value
 
     assert (
-        list(list(c) for c in m_tconfig.call_args_list)
+        m_tconfig.call_args_list
         == [[(_config["image"], ), {}] for _config in config.values()])
     assert (
-        list(list(c) for c in m_tconfig.return_value.update.call_args_list)
+        m_tconfig.return_value.update.call_args_list
         == [[(_conf,), {}] for _conf in config.values()])
     assert (
-        list(list(c)
-             for c
-             in m_tconfig.return_value.__getitem__.call_args_list)
+        m_tconfig.return_value.__getitem__.call_args_list
         == [[('type',), {}], [('ext',), {}]] * len(config))
     assert (
-        list(list(c) for c in m_pkgs.call_args_list)
+        m_pkgs.call_args_list
         == ([[(m_tconfig.return_value.__getitem__.return_value, ) * 2, {}]]
             * len(config)))
 
@@ -282,7 +280,7 @@ def test_checker_add_arguments():
     parser = MagicMock()
     checker.add_arguments(parser)
     assert (
-        list(list(c) for c in parser.add_argument.call_args_list)
+        parser.add_argument.call_args_list
         == [[('--verbosity', '-v'),
              {'choices': ['debug', 'info', 'warn', 'error'],
               'default': 'info',
@@ -393,7 +391,7 @@ async def test_checker_check_distros(patches, tests, rebuild):
         assert not await checker.check_distros()
 
     assert (
-        list(list(c) for c in m_log.return_value.info.call_args_list)
+        m_log.return_value.info.call_args_list
         == [[((f"[{name}] Testing with: "
                f'{",".join(n.name for n in tests[name]["packages"])}'),),
              {}]
@@ -404,7 +402,7 @@ async def test_checker_check_distros(patches, tests, rebuild):
              for i, package in enumerate(tests[name]["packages"])]
             for name in tests))
     assert (
-        list(list(c) for c in m_dtest.call_args_list)
+        m_dtest.call_args_list
         == expected)
 
 
@@ -420,10 +418,10 @@ def test_checker_get_test_config(patches):
             == m_config.return_value.get_config.return_value.copy.return_value)
 
     assert (
-        list(m_config.return_value.get_config.call_args)
+        m_config.return_value.get_config.call_args
         == [('IMAGE',), {}])
     assert (
-        list(m_config.return_value.get_config.return_value.copy.call_args)
+        m_config.return_value.get_config.return_value.copy.call_args
         == [(), {}])
 
 
@@ -439,7 +437,7 @@ def test_checker_get_test_packages(patches):
             == m_config.return_value.get_packages.return_value)
 
     assert (
-        list(m_config.return_value.get_packages.call_args)
+        m_config.return_value.get_packages.call_args
         == [('TYPE', 'EXT'), {}])
 
 
@@ -460,14 +458,14 @@ async def test_checker_on_checks_complete(patches):
         assert await checker.on_checks_complete() == "COMPLETE"
 
     assert (
-        (list(list(c) for c in order_mock.call_args_list))
+        order_mock.call_args_list
         == [[('TEST',), {}],
             [('DOCKER',), {}],
             [('COMPLETE',), {}]])
 
     for m in m_test, m_docker, m_complete:
         assert (
-            list(m.call_args)
+            m.call_args
             == [(), {}])
 
 
@@ -499,10 +497,10 @@ async def test_checker_run_test(patches, exiting, errors, rebuild):
         checker._active_distrotest
         == m_test.return_value.return_value)
     assert (
-        list(m_log.return_value.info.call_args)
+        m_log.return_value.info.call_args
         == [('[NAME] Testing package: PACKAGE',), {}])
     assert (
-        list(m_test.return_value.call_args)
+        m_test.return_value.call_args
         == [(checker, m_config.return_value,
              'NAME',
              'IMAGE',
@@ -531,7 +529,7 @@ async def test_checker__cleanup_docker(patches, exists):
         return
 
     assert (
-        list(m_docker.return_value.close.call_args)
+        m_docker.return_value.close.call_args
         == [(), {}])
 
 
@@ -554,5 +552,5 @@ async def test_checker__cleanup_test(patches, exists):
         return
 
     assert (
-        list(m_active.return_value.cleanup.call_args)
+        m_active.return_value.cleanup.call_args
         == [(), {}])

--- a/envoy.docker.utils/tests/test_utils.py
+++ b/envoy.docker.utils/tests/test_utils.py
@@ -34,11 +34,11 @@ async def test_util_build_image(patches, args, kwargs):
 
     temp_file = m_temp.NamedTemporaryFile
     assert (
-        list(temp_file.call_args)
+        temp_file.call_args
         == [(), {}])
 
     assert (
-        list(m_build.call_args)
+        m_build.call_args
         == [(temp_file.return_value.__enter__.return_value, ) + args,
             kwargs])
 
@@ -81,16 +81,16 @@ async def test_util__build_image(patches, stream, buildargs, error):
             assert not await utils.utils._build_image(*args, **kwargs)
 
     assert (
-        list(m_tar.open.call_args)
+        m_tar.open.call_args
         == [(tar.name,), {'fileobj': tar, 'mode': 'w'}])
     assert (
-        list(m_tar.open.return_value.__enter__.return_value.add.call_args)
+        m_tar.open.return_value.__enter__.return_value.add.call_args
         == [('CONTEXT',), {'arcname': '.'}])
     assert (
-        list(tar.seek.call_args)
+        tar.seek.call_args
         == [(0,), {}])
     assert (
-        list(docker.images.build.call_args)
+        docker.images.build.call_args
         == [(),
             {'fileobj': tar,
              'encoding': 'gzip',
@@ -99,12 +99,12 @@ async def test_util__build_image(patches, stream, buildargs, error):
              'buildargs': buildargs or {}}])
     if stream and error:
         assert (
-            list(list(c) for c in _stream.call_args_list)
+            _stream.call_args_list
             == [[('LINE1',), {}]])
         return
     elif stream:
         assert (
-            list(list(c) for c in _stream.call_args_list)
+            _stream.call_args_list
             == [[(f'LINE{i}',), {}] for i in range(1, 4)])
         return
     # the iterator should be called n + 1 for the n of items
@@ -135,9 +135,9 @@ async def test_util_docker_client(patches, raises, url):
                 pass
 
     assert (
-        list(m_docker.Docker.call_args)
+        m_docker.Docker.call_args
         == [(url,), {}])
     assert docker == m_docker.Docker.return_value
     assert (
-        list(m_docker.Docker.return_value.close.call_args)
+        m_docker.Docker.return_value.close.call_args
         == [(), {}])

--- a/envoy.docs.sphinx_runner/tests/test_sphinx_runner.py
+++ b/envoy.docs.sphinx_runner/tests/test_sphinx_runner.py
@@ -45,7 +45,7 @@ def test_sphinx_runner_build_dir(patches):
         assert runner.build_dir == m_plib.Path.return_value
 
     assert (
-        list(m_plib.Path.call_args)
+        m_plib.Path.call_args
         == [(m_temp.return_value.name, ), {}])
     assert "build_dir" not in runner.__dict__
 
@@ -98,7 +98,7 @@ def test_sphinx_runner_config_file(patches):
             == m_utils.to_yaml.return_value)
 
     assert (
-        list(m_utils.to_yaml.call_args)
+        m_utils.to_yaml.call_args
         == [(m_configs.return_value, m_fpath.return_value), {}])
     assert "config_file" in runner.__dict__
 
@@ -115,7 +115,7 @@ def test_sphinx_runner_config_file_path(patches):
             == m_build.return_value.joinpath.return_value)
 
     assert (
-        list(m_build.return_value.joinpath.call_args)
+        m_build.return_value.joinpath.call_args
         == [('build.yaml',), {}])
     assert "config_file_path" not in runner.__dict__
 
@@ -171,7 +171,7 @@ def test_sphinx_runner_descriptor_path(patches):
             == m_plib.Path.return_value)
 
     assert (
-        list(m_plib.Path.call_args)
+        m_plib.Path.call_args
         == [(m_args.return_value.descriptor_path,), {}])
     assert "descriptor_path" not in runner.__dict__
 
@@ -189,7 +189,7 @@ def test_sphinx_runner_docker_image_tag_name(patches):
             == m_re.sub.return_value)
 
     assert (
-        list(m_re.sub.call_args)
+        m_re.sub.call_args
         == [('([0-9]+\\.[0-9]+)\\.[0-9]+.*', 'v\\1-latest',
              m_version.return_value), {}])
     assert "docker_image_tag_name" not in runner.__dict__
@@ -217,7 +217,7 @@ def test_sphinx_runner_html_dir(patches):
         assert runner.html_dir == m_build.return_value.joinpath.return_value
 
     assert (
-        list(m_build.return_value.joinpath.call_args)
+        m_build.return_value.joinpath.call_args
         == [('generated', 'html'), {}])
     assert "html_dir" in runner.__dict__
 
@@ -233,7 +233,7 @@ def test_sphinx_runner_output_path(patches):
         assert runner.output_path == m_plib.Path.return_value
 
     assert (
-        list(m_plib.Path.call_args)
+        m_plib.Path.call_args
         == [(m_args.return_value.output_path, ), {}])
     assert "output_path" not in runner.__dict__
 
@@ -268,7 +268,7 @@ def test_sphinx_runner_py_compatible(patches, major, minor):
         if major == 3 and minor >= 8
         else False)
     assert (
-        list(m_bool.call_args)
+        m_bool.call_args
         == [(expected,), {}])
     assert "py_compatible" not in runner.__dict__
 
@@ -304,12 +304,12 @@ def test_sphinx_runner_rst_dir(patches, rst_tar):
         assert runner.rst_dir == m_dir.return_value.joinpath.return_value
 
     assert (
-        list(m_dir.return_value.joinpath.call_args)
+        m_dir.return_value.joinpath.call_args
         == [('generated', 'rst'), {}])
 
     if rst_tar:
         assert (
-            list(m_utils.extract.call_args)
+            m_utils.extract.call_args
             == [(m_dir.return_value.joinpath.return_value, rst_tar), {}])
     else:
         assert not m_utils.extract.called
@@ -327,7 +327,7 @@ def test_sphinx_runner_rst_tar(patches):
         assert runner.rst_tar == m_plib.Path.return_value
 
     assert (
-        list(m_plib.Path.call_args)
+        m_plib.Path.call_args
         == [(m_args.return_value.rst_tar, ), {}])
     assert "rst_tar" not in runner.__dict__
 
@@ -377,7 +377,7 @@ def test_sphinx_runner_validator_path(patches):
             == m_plib.Path.return_value)
 
     assert (
-        list(m_plib.Path.call_args)
+        m_plib.Path.call_args
         == [(m_args.return_value.validator_path,), {}])
     assert "validator_path" not in runner.__dict__
 
@@ -393,7 +393,7 @@ def test_sphinx_runner_version_file(patches):
         assert runner.version_file == m_plib.Path.return_value
 
     assert (
-        list(m_plib.Path.call_args)
+        m_plib.Path.call_args
         == [(m_args.return_value.version_file, ), {}])
     assert "version_file" not in runner.__dict__
 
@@ -418,10 +418,10 @@ def test_sphinx_runner_version_number(patches, version):
         assert not m_file.called
         return
     assert (
-        list(m_file.return_value.read_text.call_args)
+        m_file.return_value.read_text.call_args
         == [(), {}])
     assert (
-        list(m_file.return_value.read_text.return_value.strip.call_args)
+        m_file.return_value.read_text.return_value.strip.call_args
         == [(), {}])
 
     assert "version_number" in runner.__dict__
@@ -446,7 +446,7 @@ def test_sphinx_runner_version_string(patches, docs_tag):
                 == (f"{m_version.return_value}-"
                     f"{m_sha.return_value.__getitem__.return_value}"))
             assert (
-                list(m_sha.return_value.__getitem__.call_args)
+                m_sha.return_value.__getitem__.call_args
                 == [(slice(None, 6, None),), {}])
 
     assert "version_string" not in runner.__dict__
@@ -463,10 +463,10 @@ def test_sphinx_runner_add_arguments(patches):
         runner.add_arguments(parser)
 
     assert (
-        list(m_super.call_args)
+        m_super.call_args
         == [(parser, ), {}])
     assert (
-        list(list(c) for c in parser.add_argument.call_args_list)
+        parser.add_argument.call_args_list
         == [[('--build_sha',), {}],
             [('--docs_tag',), {}],
             [('--version_file',), {}],
@@ -501,7 +501,7 @@ def test_sphinx_runner_build_html(patches, fails):
             runner.build_html()
 
     assert (
-        list(m_sphinx.call_args)
+        m_sphinx.call_args
         == [(m_args.return_value,), {}])
 
     if fails:
@@ -523,7 +523,7 @@ def test_sphinx_runner_build_summary(patches):
         runner.build_summary()
 
     assert (
-        list(list(c) for c in m_print.call_args_list)
+        m_print.call_args_list
         == [[(), {}],
             [(m_color.return_value,), {}],
             [(m_color.return_value,), {}],
@@ -535,7 +535,7 @@ def test_sphinx_runner_build_summary(patches):
             [(m_color.return_value,), {}],
             [(), {}]])
     assert (
-        list(list(c) for c in m_color.call_args_list)
+        m_color.call_args_list
         == [[('#### Sphinx build configs #####################',), {}],
             [('###',), {}],
             [('###',), {}],
@@ -604,7 +604,7 @@ def test_sphinx_runner_check_env(
         return
 
     assert (
-        list(m_rst.return_value.joinpath.call_args)
+        m_rst.return_value.joinpath.call_args
         == [("version_history", "current.rst"), {}])
 
     if version_number not in current:
@@ -629,7 +629,7 @@ async def test_sphinx_runner_cleanup(patches, exists):
     assert "tempdir" not in runner.__dict__
     if exists:
         assert (
-            list(m_temp.return_value.cleanup.call_args)
+            m_temp.return_value.cleanup.call_args
             == [(), {}])
     else:
         assert not m_temp.called
@@ -657,21 +657,21 @@ def test_sphinx_runner_save_html(patches, tarlike, exists, is_file):
 
     if exists:
         assert (
-            list(m_log.return_value.warning.call_args)
+            m_log.return_value.warning.call_args
             == [(f"Output path ({m_out.return_value}) exists, "
                  "removing", ), {}])
         assert (
-            list(m_out.return_value.is_file.call_args)
+            m_out.return_value.is_file.call_args
             == [(), {}])
         if is_file:
             assert (
-                list(m_out.return_value.unlink.call_args)
+                m_out.return_value.unlink.call_args
                 == [(), {}])
             assert not m_shutil.rmtree.called
         else:
             assert not m_out.return_value.unlink.called
             assert (
-                list(m_shutil.rmtree.call_args)
+                m_shutil.rmtree.call_args
                 == [(m_out.return_value, ), {}])
 
     else:
@@ -681,22 +681,22 @@ def test_sphinx_runner_save_html(patches, tarlike, exists, is_file):
         assert not m_shutil.rmtree.called
 
     assert (
-        list(m_utils.is_tarlike.call_args)
+        m_utils.is_tarlike.call_args
         == [(m_out.return_value, ), {}])
 
     if not tarlike:
         assert not m_tar.open.called
         assert (
-            list(m_shutil.copytree.call_args)
+            m_shutil.copytree.call_args
             == [(m_html.return_value, m_out.return_value, ), {}])
         return
 
     assert not m_shutil.copytree.called
     assert (
-        list(m_tar.open.call_args)
+        m_tar.open.call_args
         == [(m_out.return_value, 'w'), {}])
     assert (
-        list(m_tar.open.return_value.__enter__.return_value.add.call_args)
+        m_tar.open.return_value.__enter__.return_value.add.call_args
         == [(m_html.return_value,), {'arcname': '.'}])
 
 
@@ -734,18 +734,18 @@ async def test_sphinx_runner_run(patches, check_fails, build_fails):
             == (1 if (check_fails or build_fails) else None))
 
     assert (
-        list(m_validate.call_args)
+        m_validate.call_args
         == [(), {}])
     assert (
-        list(m_check.call_args)
+        m_check.call_args
         == [(), {}])
     assert (
-        list(m_os.environ.__setitem__.call_args)
+        m_os.environ.__setitem__.call_args
         == [('ENVOY_DOCS_BUILD_CONFIG', str(m_config.return_value)), {}])
 
     if check_fails:
         assert (
-            list(m_print.call_args)
+            m_print.call_args
             == [(_check_error,), {}])
         assert not m_summary.called
         assert not m_build.called
@@ -753,22 +753,22 @@ async def test_sphinx_runner_run(patches, check_fails, build_fails):
         return
 
     assert (
-        list(m_summary.call_args)
+        m_summary.call_args
         == [(), {}])
     assert (
-        list(m_build.call_args)
+        m_build.call_args
         == [(), {}])
 
     if build_fails:
         assert (
-            list(m_print.call_args)
+            m_print.call_args
             == [(_build_error,), {}])
         assert not m_save.called
         return
 
     assert not m_print.called
     assert (
-        list(m_save.call_args)
+        m_save.call_args
         == [(), {}])
 
 
@@ -795,7 +795,7 @@ def test_sphinx_runner_validate_args(patches, exists, overwrite):
             assert not runner.validate_args()
 
     assert (
-        list(m_out.return_value.exists.call_args)
+        m_out.return_value.exists.call_args
         == [(), {}])
     if not exists:
         assert not m_overwrite.called
@@ -816,5 +816,5 @@ def test_sphinx_runner__color(patches, color):
             == (f"{m_colors.return_value.__getitem__.return_value}"
                 f"MSG{m_style.RESET_ALL}"))
     assert (
-        list(m_colors.return_value.__getitem__.call_args)
+        m_colors.return_value.__getitem__.call_args
         == [(color or "chrome",), {}])

--- a/envoy.github.abstract/tests/test_assets.py
+++ b/envoy.github.abstract/tests/test_assets.py
@@ -129,10 +129,10 @@ async def test_assets_dunder_aiter(patches, raises):
                 _results.append(result)
 
     assert (
-        list(m_run.call_args)
+        m_run.call_args
         == [(), {}])
     assert (
-        list(m_enter.call_args)
+        m_enter.call_args
         == [(), {}])
 
     if raises:
@@ -147,7 +147,7 @@ async def test_assets_dunder_aiter(patches, raises):
         return
 
     assert (
-        list(m_exit.call_args)
+        m_exit.call_args
         == [(None, None, None), {}])
     assert _results == list(range(0, 5))
 
@@ -175,7 +175,7 @@ def test_assets_tasks(patches):
         assert release_assets.tasks == m_concurrent.return_value
 
     assert (
-        list(m_concurrent.call_args)
+        m_concurrent.call_args
         == [(m_await.return_value,), dict(limit=23)])
     assert "tasks" not in release_assets.__dict__
 
@@ -190,7 +190,7 @@ def test_assets_tempdir(patches):
         assert release_assets.tempdir == m_temp.TemporaryDirectory.return_value
 
     assert (
-        list(m_temp.TemporaryDirectory.call_args)
+        m_temp.TemporaryDirectory.call_args
         == [(), {}])
 
 
@@ -209,7 +209,7 @@ def test_assets_cleanup(patches, tempdir):
     assert "tempdir" not in release_assets.__dict__
     if tempdir:
         assert (
-            list(m_temp.return_value.cleanup.call_args)
+            m_temp.return_value.cleanup.call_args
             == [(), {}])
     else:
         assert not m_temp.called
@@ -220,7 +220,7 @@ def test_assets_fail():
     release_assets = DummyGithubReleaseAssets(release, "PATH")
     assert release_assets.fail("FAILURE") == release.fail.return_value
     assert (
-        list(release.fail.call_args)
+        release.fail.call_args
         == [("FAILURE", ), {}])
 
 
@@ -274,7 +274,7 @@ async def test_assets_run(patches, raises):
             return
     if raises:
         assert (
-            list(m_fail.call_args)
+            m_fail.call_args
             == [("AN ERROR OCCURRED", ), {}])
         assert results == [dict(error=m_fail.return_value)]
         return
@@ -300,7 +300,7 @@ def test_assets_fetcher_constructor(patches, asset_types, append):
         fetcher = DummyGithubReleaseAssetsFetcher(*args)
 
     assert (
-        list(m_super.call_args)
+        m_super.call_args
         == [("RELEASE", "PATH"), {}])
     assert fetcher._asset_types == asset_types
     assert fetcher._append == (append or False)
@@ -328,7 +328,7 @@ def test_assets_fetcher_asset_types(patches, asset_types):
 
     if not asset_types:
         assert (
-            list(m_re.compile.call_args)
+            m_re.compile.call_args
             == [(".*", ), {}])
     else:
         assert not m_re.compile.called
@@ -370,10 +370,10 @@ async def test_assets_fetcher_awaitables(patches, asset_types):
             for x in returned_assets
             if x["name"] in asset_types])
     assert (
-        list(list(c) for c in m_type.call_args_list)
+        m_type.call_args_list
         == [[(asset,), {}] for asset in returned_assets])
     assert (
-        list(list(c) for c in m_download.call_args_list)
+        m_download.call_args_list
         == [[({'name': asset["name"], 'asset_type': asset["name"]},), {}]
             for asset in returned_assets
             if asset["name"] in asset_types])
@@ -452,11 +452,11 @@ async def test_assets_pusher_awaitables(patches):
 
     assert results == [m_upload.return_value for i in range(0, 5)]
     assert (
-        list(list(c) for c in m_upload.call_args_list)
+        m_upload.call_args_list
         == [[(artefact, m_url.return_value), {}]
             for artefact in artefacts])
     assert (
-        list(list(c) for c in m_url.call_args_list)
+        m_url.call_args_list
         == [[(artefact.name,), {}]
             for artefact in artefacts])
 

--- a/envoy.github.abstract/tests/test_command.py
+++ b/envoy.github.abstract/tests/test_command.py
@@ -49,7 +49,7 @@ def test_release_artefacts(patches, assets):
                      for asset in assets or []))
 
     assert (
-        list(list(c) for c in m_plib.Path.call_args_list)
+        m_plib.Path.call_args_list
         == [[(asset,), {}] for asset in assets or []])
     assert "artefacts" in command.__dict__
 
@@ -95,7 +95,7 @@ def test_release_command_release(patches):
             == m_manager.return_value.__getitem__.return_value)
 
     assert (
-        list(m_manager.return_value.__getitem__.call_args)
+        m_manager.return_value.__getitem__.call_args
         == [(m_version.return_value, ), {}])
     assert "release" in command.__dict__
 
@@ -118,5 +118,5 @@ def test_release_command_add_arguments():
     parser = MagicMock()
     assert not command.add_arguments(parser)
     assert (
-        list(list(c) for c in parser.add_argument.call_args_list)
+        parser.add_argument.call_args_list
         == [[("version", ), dict(help="Github release version")]])

--- a/envoy.github.abstract/tests/test_runner.py
+++ b/envoy.github.abstract/tests/test_runner.py
@@ -81,10 +81,10 @@ def test_runner_oauth_token(patches, token_set, token_exists):
         assert not m_file.return_value.read_text.called
         return
     assert (
-        list(m_file.return_value.read_text.call_args)
+        m_file.return_value.read_text.call_args
         == [(), {}])
     assert (
-        list(m_file.return_value.read_text.return_value.strip.call_args)
+        m_file.return_value.read_text.return_value.strip.call_args
         == [(), {}])
 
 
@@ -110,7 +110,7 @@ def test_runner_oauth_token_file(patches, token_set):
         assert not m_plib.Path.called
         return
     assert (
-        list(m_plib.Path.call_args)
+        m_plib.Path.call_args
         == [(m_args.return_value.oauth_token_file, ), {}])
 
 
@@ -126,7 +126,7 @@ def test_runner_path(patches):
         assert run.path == m_plib.Path.return_value
 
     assert (
-        list(m_plib.Path.call_args)
+        m_plib.Path.call_args
         == [(m_tempdir.return_value.name, ), {}])
 
 
@@ -151,7 +151,7 @@ def test_runner_release_manager(patches):
         assert run.release_manager == m_class.return_value.return_value
 
     assert (
-        list(m_class.return_value.call_args)
+        m_class.return_value.call_args
         == [(m_path.return_value,
              m_repo.return_value),
             {'log': m_log.return_value,
@@ -170,10 +170,10 @@ def test_runner_add_arguments(patches):
         run.add_arguments(parser)
 
     assert (
-        list(m_super.call_args)
+        m_super.call_args
         == [(parser, ), {}])
     assert (
-        list(list(c) for c in parser.add_argument.call_args_list)
+        parser.add_argument.call_args_list
         == [[('repository',),
              {'help': 'Github repository'}],
             [('oauth_token_file',),
@@ -202,7 +202,7 @@ async def test_runner_cleanup(patches, indict):
     assert "release_manager" not in run.__dict__
     if indict:
         assert (
-            list(m_manager.return_value.close.call_args)
+            m_manager.return_value.close.call_args
             == [(), {}])
     else:
         assert not m_manager.return_value.close.called

--- a/envoy.github.release/tests/test_assets.py
+++ b/envoy.github.release/tests/test_assets.py
@@ -23,7 +23,7 @@ def test_fetcher_constructor(patches):
         concurrency = fetcher.concurrency
 
     assert (
-        list(m_super.call_args)
+        m_super.call_args
         == [("RELEASE", "PATH", "ASSET_TYPES"), {}])
 
     assert concurrency == m_concurrency.return_value
@@ -51,15 +51,15 @@ def test_fetcher_dunder_exit(patches):
         assert not fetcher.__exit__(*args)
 
     assert (
-        list(m_tar.open.call_args)
+        m_tar.open.call_args
         == [(m_superpath.return_value,
              m_mode.return_value), {}])
     assert (
-        list(m_tar.open.return_value.__enter__.return_value.add.call_args)
+        m_tar.open.return_value.__enter__.return_value.add.call_args
         == [(m_path.return_value, ),
             dict(arcname=m_version.return_value)])
     assert (
-        list(m_super.call_args)
+        m_super.call_args
         == [tuple(args), {}])
 
 
@@ -76,7 +76,7 @@ def test_fetcher_is_tarlike(patches):
         assert fetcher.is_tarlike == m_utils.is_tarlike.return_value
 
     assert (
-        list(m_utils.is_tarlike.call_args)
+        m_utils.is_tarlike.call_args
         == [(m_path.return_value, ), {}])
     assert "is_tarlike" in fetcher.__dict__
 
@@ -135,7 +135,7 @@ def test_fetcher_path(patches, exists, is_tarlike):
             if not is_tarlike
             else f"Output tarball exists: {m_path.return_value}")
         assert (
-            list(m_fail.call_args)
+            m_fail.call_args
             == [(msg,), {}])
     else:
         assert not m_fail.called
@@ -145,10 +145,10 @@ def test_fetcher_path(patches, exists, is_tarlike):
         assert not m_temp.called
     else:
         assert (
-            list(m_plib.Path.call_args)
+            m_plib.Path.call_args
             == [(m_temp.return_value.name,), {}])
     assert (
-        list(list(c) for c in m_path.call_args_list)
+        m_path.call_args_list
         == [[(), {}]] * path_calls)
 
 
@@ -173,12 +173,12 @@ async def test_fetcher_download(patches):
             == m_save.return_value)
 
     assert (
-        list(m_save.call_args)
+        m_save.call_args
         == [("ASSET TYPE",
              "ASSET NAME",
              m_session.return_value.get.return_value), {}])
     assert (
-        list(m_session.return_value.get.call_args)
+        m_session.return_value.get.call_args
         == [('ASSET DOWNLOAD URL',), {}])
 
 
@@ -202,7 +202,7 @@ async def test_fetcher_save(patches, status):
     expected = dict(name="NAME", outfile=outfile)
     if status != 200:
         assert (
-            list(m_fail.call_args)
+            m_fail.call_args
             == [(f"Failed downloading, got response:\n{download}", ), {}])
         expected["error"] = m_fail.return_value
     else:
@@ -210,18 +210,18 @@ async def test_fetcher_save(patches, status):
 
     assert result == expected
     assert (
-        list(m_path.return_value.joinpath.call_args)
+        m_path.return_value.joinpath.call_args
         == [('ASSET TYPE', 'NAME'), {}])
     assert (
-        list(outfile.parent.mkdir.call_args)
+        outfile.parent.mkdir.call_args
         == [(), dict(exist_ok=True)])
     writer = m_stream.writer
     assert (
-        list(writer.call_args)
+        writer.call_args
         == [(outfile, ), {}])
     stream_bytes = writer.return_value.__aenter__.return_value.stream_bytes
     assert (
-        list(stream_bytes.call_args)
+        stream_bytes.call_args
         == [(download, ), {}])
 
 
@@ -238,7 +238,7 @@ def test_pusher_constructor(patches):
         concurrency = pusher.concurrency
 
     assert (
-        list(m_super.call_args)
+        m_super.call_args
         == [("RELEASE", "PATH"), {}])
 
     assert concurrency == m_concurrency.return_value
@@ -285,10 +285,10 @@ def test_pusher_artefacts(patches, file_exts, globs):
         artefacts
         == [mock_globs[x] for x in globs if x[1:] in file_exts])
     assert (
-        list(pusher._artefacts_glob.format.call_args)
+        pusher._artefacts_glob.format.call_args
         == [(), dict(version=m_version.return_value)])
     assert (
-        list(m_path.return_value.glob.call_args)
+        m_path.return_value.glob.call_args
         == [(pusher._artefacts_glob.format.return_value, ), {}])
 
 
@@ -303,7 +303,7 @@ def test_pusher_is_dir(patches):
         assert pusher.is_dir == m_path.return_value.is_dir.return_value
 
     assert (
-        list(m_path.return_value.is_dir.call_args)
+        m_path.return_value.is_dir.call_args
         == [(), {}])
     assert "is_dir" in pusher.__dict__
 
@@ -320,7 +320,7 @@ def test_pusher_is_tarball(patches):
         assert pusher.is_tarball == m_tar.is_tarfile.return_value
 
     assert (
-        list(m_tar.is_tarfile.call_args)
+        m_tar.is_tarfile.call_args
         == [(m_path.return_value, ), {}])
     assert "is_tarball" in pusher.__dict__
 
@@ -363,7 +363,7 @@ def test_pusher_path(patches, is_dir, is_tarball):
     assert "path" in pusher.__dict__
     if is_tarball:
         assert (
-            list(m_utils.extract.call_args)
+            m_utils.extract.call_args
             == [(m_temp.return_value.name,
                  m_path.return_value), {}])
     else:
@@ -409,15 +409,15 @@ async def test_pusher_upload(patches, name, asset_names, error, state):
         assert not m_stream.reader.called
         assert not m_github.return_value.post.called
         assert (
-            list(m_fail.call_args)
+            m_fail.call_args
             == [(f"Asset exists already {name}", ), {}])
         return
 
     assert (
-        list(m_stream.reader.call_args)
+        m_stream.reader.call_args
         == [(artefact, ), {}])
     assert (
-        list(m_github.return_value.post.call_args)
+        m_github.return_value.post.call_args
         == [("URL", ),
             dict(data=m_stream.reader.return_value.__aenter__.return_value,
                  content_type="application/octet-stream")])
@@ -428,7 +428,7 @@ async def test_pusher_upload(patches, name, asset_names, error, state):
                 'url': 'URL',
                 'error': m_fail.return_value})
         assert (
-            list(m_fail.call_args)
+            m_fail.call_args
             == [(("Something went wrong uploading "
                   f"{name} -> URL, got:\n{response}"), ),
                 {}])
@@ -438,6 +438,6 @@ async def test_pusher_upload(patches, name, asset_names, error, state):
         == {'name': name,
             'url': response.__getitem__.return_value})
     assert (
-        list(response.__getitem__.call_args)
+        response.__getitem__.call_args
         == [("url", ), {}])
     assert not m_fail.called

--- a/envoy.github.release/tests/test_manager.py
+++ b/envoy.github.release/tests/test_manager.py
@@ -66,7 +66,7 @@ async def test_release_manager_async_contextmanager(patches):
             assert isinstance(releaser, GithubReleaseManager)
             assert not m_close.called
         assert (
-            list(m_close.call_args)
+            m_close.call_args
             == [(), {}])
 
 
@@ -80,7 +80,7 @@ def test_release_manager_dunder_getitem(patches):
         assert releaser["X.Y.Z"] == m_release.return_value
 
     assert (
-        list(m_release.call_args)
+        m_release.call_args
         == [(releaser, "X.Y.Z"), {}])
 
 
@@ -113,7 +113,7 @@ def test_release_manager_github(patches, oauth_token, user, github):
         assert not m_api.aiohttp.GitHubAPI.called
         return
     assert (
-        list(m_api.aiohttp.GitHubAPI.call_args)
+        m_api.aiohttp.GitHubAPI.call_args
         == [(m_session.return_value, user or ""),
             {'oauth_token': oauth_token}])
 
@@ -141,7 +141,7 @@ def test_release_manager_log(patches, log):
         return
 
     assert (
-        list(m_log.VerboseLogger.call_args)
+        m_log.VerboseLogger.call_args
         == [('envoy.github.release.manager',), {}])
 
 
@@ -158,7 +158,7 @@ def test_release_manager_path(patches):
 
     assert "path" in releaser.__dict__
     assert (
-        list(m_plib.Path.call_args)
+        m_plib.Path.call_args
         == [('PATH',), {}])
 
 
@@ -213,7 +213,7 @@ async def test_release_manager_releases(patches):
         assert await releaser.releases == list(range(0, 5))
 
     assert (
-        list(getiter_mock.call_args)
+        getiter_mock.call_args
         == [(str(m_releases.return_value), ), {}])
     assert not hasattr(releaser, async_property.cache_name)
 
@@ -228,7 +228,7 @@ def test_release_manager_releases_url(patches):
         assert releaser.releases_url == m_plib.PurePosixPath.return_value
 
     assert (
-        list(m_plib.PurePosixPath.call_args)
+        m_plib.PurePosixPath.call_args
         == [("/repos/REPOSITORY/releases", ), {}])
     assert "releases_url" in releaser.__dict__
 
@@ -254,7 +254,7 @@ def test_release_manager_session(patches, session):
         assert not m_http.ClientSession.called
         return
     assert (
-        list(m_http.ClientSession.call_args)
+        m_http.ClientSession.call_args
         == [(), {}])
 
 
@@ -269,7 +269,7 @@ def test_release_manager_version_re(patches):
         assert releaser.version_re == m_re.compile.return_value
 
     assert (
-        list(m_re.compile.call_args)
+        m_re.compile.call_args
         == [("VERSION RE", ), {}])
 
 
@@ -294,7 +294,7 @@ async def test_release_manager_close(patches, session):
         return
 
     assert (
-        list(m_session.return_value.close.call_args)
+        m_session.return_value.close.call_args
         == [(), {}])
 
 
@@ -320,7 +320,7 @@ def test_release_manager_fail(patches, continues):
         return
 
     assert (
-        list(m_log.return_value.warning.call_args)
+        m_log.return_value.warning.call_args
         == [("MESSAGE", ), {}])
 
 
@@ -331,7 +331,7 @@ def test_release_manager_format_version():
         releaser.format_version("VERSION")
         == releaser._version_format.format.return_value)
     assert (
-        list(releaser._version_format.format.call_args)
+        releaser._version_format.format.call_args
         == [(), dict(version="VERSION")])
 
 
@@ -363,18 +363,18 @@ def test_release_manager_parse_version(patches, version, raises):
                     else m_packaging.return_value))
 
     assert (
-        list(m_version.return_value.sub.call_args)
+        m_version.return_value.sub.call_args
         == [(r"\1", "VERSION"), {}])
     if version:
         assert (
-            list(m_packaging.call_args)
+            m_packaging.call_args
             == [(m_version.return_value.sub.return_value, ), {}])
     else:
         assert not m_packaging.called
 
     if not version or raises and raises != BaseException:
         assert (
-            list(m_log.return_value.warning.call_args)
+            m_log.return_value.warning.call_args
             == [("Unable to parse version: VERSION", ), {}])
     else:
         assert not m_log.called

--- a/envoy.github.release/tests/test_release.py
+++ b/envoy.github.release/tests/test_release.py
@@ -56,7 +56,7 @@ async def test_release_asset_names(patches):
 
     for _asset in _assets:
         assert (
-            list(_asset.__getitem__.call_args)
+            _asset.__getitem__.call_args
             == [('name',), {}])
 
     assert "asset_names" in release.__async_prop_cache__
@@ -91,7 +91,7 @@ async def test_release_assets(patches, raises):
                 == _get.return_value)
 
     assert (
-        list(_get.call_args)
+        _get.call_args
         == [(_url.return_value,), {}])
     if not raises:
         assert "assets" in release.__async_prop_cache__
@@ -111,7 +111,7 @@ async def test_release_assets_url(patches):
             == _release.return_value.__getitem__.return_value)
 
     assert (
-        list(_release.return_value.__getitem__.call_args)
+        _release.return_value.__getitem__.call_args
         == [('assets_url',), {}])
     assert "assets_url" in getattr(release, async_property.cache_name)
 
@@ -131,7 +131,7 @@ async def test_release_delete_url(patches):
             == m_url.return_value.joinpath.return_value)
 
     assert (
-        list(m_url.return_value.joinpath.call_args)
+        m_url.return_value.joinpath.call_args
         == [(str(_id.return_value), ), {}])
     assert "delete_url" in getattr(release, async_property.cache_name)
 
@@ -179,7 +179,7 @@ async def test_release_release_id(patches):
             == _release.return_value.__getitem__.return_value)
 
     assert (
-        list(_release.return_value.__getitem__.call_args)
+        _release.return_value.__getitem__.call_args
         == [('id',), {}])
     assert "release_id" in getattr(release, async_property.cache_name)
 
@@ -214,13 +214,13 @@ async def test_release_upload_url(patches):
             == split.return_value.__getitem__.return_value)
 
     assert (
-        list(_release.return_value.__getitem__.call_args)
+        _release.return_value.__getitem__.call_args
         == [('upload_url',), {}])
     assert (
-        list(split.call_args)
+        split.call_args
         == [('{',), {}])
     assert (
-        list(split.return_value.__getitem__.call_args)
+        split.return_value.__getitem__.call_args
         == [(0,), {}])
     assert "upload_url" in release.__async_prop_cache__
 
@@ -230,7 +230,7 @@ def test_release_version_name(patches):
     release = GithubRelease(_manager, "VERSION")
     release.version_name == _manager.format_version.return_value
     assert (
-        list(_manager.format_version.call_args)
+        _manager.format_version.call_args
         == [("VERSION",), {}])
 
 
@@ -247,7 +247,7 @@ def test_release_version_url(patches):
             == m_releases.return_value.joinpath.return_value)
 
     assert (
-        list(m_releases.return_value.joinpath.call_args)
+        m_releases.return_value.joinpath.call_args
         == [("tags", m_version.return_value), {}])
     assert "version_url" in release.__dict__
 
@@ -297,17 +297,17 @@ async def test_release_create(patches, exists, assets, raises):
     expected = {}
     if not exists:
         assert (
-            list(m_log.return_value.notice.call_args)
+            m_log.return_value.notice.call_args
             == [("Creating release VERSION", ), {}])
         assert (
-            list(m_github.return_value.post.call_args)
+            m_github.return_value.post.call_args
             == [(str(m_url.return_value), ),
                 dict(data=dict(tag_name=m_version.return_value))])
         assert not m_fail.called
         if not raises:
             expected["release"] = m_github.return_value.post.return_value
             assert (
-                list(m_log.return_value.success.call_args)
+                m_log.return_value.success.call_args
                 == [("Release created VERSION", ), {}])
         else:
             assert not m_log.return_value.success.called
@@ -315,7 +315,7 @@ async def test_release_create(patches, exists, assets, raises):
         assert not m_github.return_value.post.called
         assert not m_log.called
         assert (
-            list(m_fail.call_args)
+            m_fail.call_args
             == [(f"Release {m_version.return_value} already exists", ), {}])
 
     if not exists and raises:
@@ -324,7 +324,7 @@ async def test_release_create(patches, exists, assets, raises):
     if assets:
         expected["PUSHED"] = True
         assert (
-            list(m_push.call_args)
+            m_push.call_args
             == [(assets, ), {}])
     else:
         assert not m_push.called
@@ -372,16 +372,16 @@ async def test_release_delete(patches, exists, raises):
             assert not m_github.called
             return
         assert (
-            list(m_log.return_value.notice.call_args)
+            m_log.return_value.notice.call_args
             == [(f"Deleting release version: {m_version.return_value}", ), {}])
         assert (
-            list(m_github.return_value.delete.call_args)
+            m_github.return_value.delete.call_args
             == [(str(_url.return_value), ), {}])
         if raises:
             assert not m_log.return_value.success.called
             return
         assert (
-            list(m_log.return_value.success.call_args)
+            m_log.return_value.success.call_args
             == [(f"Release version deleted: {m_version.return_value}", ), {}])
 
 
@@ -390,7 +390,7 @@ def test_release_fail():
     release = GithubRelease(manager, "VERSION")
     assert release.fail("FAILURE") == manager.fail.return_value
     assert (
-        list(manager.fail.call_args)
+        manager.fail.call_args
         == [("FAILURE", ), {}])
 
 
@@ -431,11 +431,11 @@ async def test_release_fetch(patches, asset_types, errors):
         assert await release.fetch("PATH", **kwargs) == expected
 
     assert (
-        list(m_log.return_value.notice.call_args)
+        m_log.return_value.notice.call_args
         == [(("Downloading assets for release version: "
               f"{m_version.return_value} -> PATH"), ), {}])
     assert (
-        list(fetched.call_args)
+        fetched.call_args
         == [(release, 'PATH', asset_types, False), {}])
 
 
@@ -465,7 +465,7 @@ async def test_release_get(patches, raises):
                 await release.get()
                 == m_github.return_value.getitem.return_value)
     assert (
-        list(m_github.return_value.getitem.call_args)
+        m_github.return_value.getitem.call_args
         == [(str(m_url.return_value), ), {}])
 
 
@@ -520,27 +520,27 @@ async def test_release_push(patches, raises, errors):
             assert await release.push(artefacts) == expected
 
     assert (
-        list(m_log.return_value.notice.call_args)
+        m_log.return_value.notice.call_args
         == [("Pushing assets for VERSION", ), {}])
 
     if raises:
         assert (
-            list(list(c) for c in m_pusher.return_value.call_args_list)
+            m_pusher.return_value.call_args_list
             == [[(release, 'ARTEFACTS0'), {}]])
         assert not m_log.return_value.info.called
     else:
         assert (
-            list(list(c) for c in m_pusher.return_value.call_args_list)
+            m_pusher.return_value.call_args_list
             == [[(release, f'ARTEFACTS{x}'), {}] for x in range(0, 5)])
 
     if raises or errors:
         assert not m_log.return_value.success.called
     else:
         assert (
-            list(m_log.return_value.success.call_args)
+            m_log.return_value.success.call_args
             == [("Assets uploaded: VERSION", ), {}])
         assert (
-            list(list(c) for c in m_log.return_value.info.call_args_list)
+            m_log.return_value.info.call_args_list
             == [[(f'Release file uploaded ARTEFACTS{i}_ASSET{x}',), {}]
                 for i in range(0, 5)
                 for x in range(0, 5)])

--- a/envoy.gpg.identity/tests/test_identity.py
+++ b/envoy.gpg.identity/tests/test_identity.py
@@ -53,10 +53,10 @@ def test_identity_email(patches):
         assert gpg.email == m_parse.return_value.__getitem__.return_value
 
     assert (
-        list(m_parse.return_value.__getitem__.call_args)
+        m_parse.return_value.__getitem__.call_args
         == [(1,), {}])
     assert (
-        list(m_parse.call_args)
+        m_parse.call_args
         == [(m_uid.return_value,), {}])
     assert "email" in gpg.__dict__
 
@@ -71,7 +71,7 @@ def test_identity_fingerprint(patches):
         assert gpg.fingerprint == m_key.return_value.__getitem__.return_value
 
     assert (
-        list(m_key.return_value.__getitem__.call_args)
+        m_key.return_value.__getitem__.call_args
         == [('fingerprint',), {}])
 
     assert "fingerprint" not in gpg.__dict__
@@ -109,7 +109,7 @@ def test_identity_gen_key_data(patches, name, email):
         assert not m_gpg.called
         return
     assert (
-        list(m_gpg.return_value.gen_key_input.call_args)
+        m_gpg.return_value.gen_key_input.call_args
         == [(),
             dict(name_real=name,
                  name_email=email,
@@ -129,7 +129,7 @@ def test_identity_gpg(patches):
         assert gpg.gpg == m_gpg.return_value
 
     assert (
-        list(m_gpg.call_args)
+        m_gpg.call_args
         == [(), dict(gnupghome=m_home.return_value)])
 
     assert "gpg" in gpg.__dict__
@@ -161,14 +161,14 @@ def test_identity_gnupg_home(patches, home, exists):
 
     assert "gnupg_home" not in gpg.__dict__
     assert (
-        list(m_os.environ.__setitem__.call_args)
+        m_os.environ.__setitem__.call_args
         == [("GNUPGHOME", str(home_path)), {}])
     assert (
-        list(home_path.exists.call_args)
+        home_path.exists.call_args
         == [(), {}])
     if not exists:
         assert (
-            list(home_path.mkdir.call_args)
+            home_path.mkdir.call_args
             == [(), {}])
     else:
         assert not home_path.mkdir.called
@@ -176,7 +176,7 @@ def test_identity_gnupg_home(patches, home, exists):
         assert not m_home.called
         return
     assert (
-        list(m_home.return_value.joinpath.call_args)
+        m_home.return_value.joinpath.call_args
         == [('.gnupg', ), {}])
 
 
@@ -204,18 +204,18 @@ def test_identity_gpg_bin(patches, gpg1, gpg2):
 
     if gpg2 or gpg1:
         assert (
-            list(m_plib.Path.call_args)
+            m_plib.Path.call_args
             == [(gpg2 or gpg1, ), {}])
     else:
         assert not m_plib.Path.called
 
     if gpg2:
         assert (
-            list(list(c) for c in m_shutil.which.call_args_list)
+            m_shutil.which.call_args_list
             == [[('gpg2',), {}]])
         return
     assert (
-        list(list(c) for c in m_shutil.which.call_args_list)
+        m_shutil.which.call_args_list
         == [[('gpg2',), {}], [('gpg',), {}]])
 
 
@@ -232,16 +232,16 @@ def test_identity_home(patches):
 
     # m_os.environ.__getitem__.return_value
     assert (
-        list(m_plib.Path.call_args)
+        m_plib.Path.call_args
         == [(m_os.environ.get.return_value, ), {}])
     assert (
-        list(m_os.environ.get.call_args)
+        m_os.environ.get.call_args
         == [('HOME', m_pwd.getpwuid.return_value.pw_dir), {}])
     assert (
-        list(m_pwd.getpwuid.call_args)
+        m_pwd.getpwuid.call_args
         == [(m_os.getuid.return_value,), {}])
     assert (
-        list(m_os.getuid.call_args)
+        m_os.getuid.call_args
         == [(), {}])
 
     assert "home" in gpg.__dict__
@@ -263,7 +263,7 @@ def test_identity_log(patches, log):
         else:
             assert gpg.log == m_log.getLogger.return_value
             assert (
-                list(m_log.getLogger.call_args)
+                m_log.getLogger.call_args
                 == [(gpg.__class__.__name__, ), {}])
 
 
@@ -286,7 +286,7 @@ def test_identity_identity_id(patches, name, email):
 
     if name and email:
         assert (
-            list(m_format.call_args)
+            m_format.call_args
             == [(('NAME', 'EMAIL'),), {}])
         assert result == m_format.return_value
         return
@@ -306,10 +306,10 @@ def test_identity_name(patches):
         assert gpg.name == m_parse.return_value.__getitem__.return_value
 
     assert (
-        list(m_parse.return_value.__getitem__.call_args)
+        m_parse.return_value.__getitem__.call_args
         == [(0,), {}])
     assert (
-        list(m_parse.call_args)
+        m_parse.call_args
         == [(m_uid.return_value,), {}])
     assert "name" in gpg.__dict__
 
@@ -348,10 +348,10 @@ def test_identity_signing_key(patches, key, name, email):
             _match_attempts = _keys
 
     assert (
-        list(m_gpg.return_value.list_keys.call_args)
+        m_gpg.return_value.list_keys.call_args
         == [(True, ), dict(keys=m_id.return_value)])
     assert (
-        list(list(c) for c in m_match.call_args_list)
+        m_match.call_args_list
         == [[(k,), {}] for k in _match_attempts])
 
 
@@ -365,7 +365,7 @@ def test_identity_uid(patches):
         assert gpg.uid == m_key.return_value.__getitem__.return_value
 
     assert (
-        list(m_key.return_value.__getitem__.call_args)
+        m_key.return_value.__getitem__.call_args
         == [('uid',), {}])
 
     assert "uid" not in gpg.__dict__
@@ -384,10 +384,10 @@ def test_identity_export_key(patches):
             == m_gpg.return_value.export_keys.return_value)
 
     assert (
-        list(m_gpg.return_value.export_keys.call_args)
+        m_gpg.return_value.export_keys.call_args
         == [(), dict(keyids=[m_key.return_value.__getitem__.return_value])])
     assert (
-        list(m_key.return_value.__getitem__.call_args)
+        m_key.return_value.__getitem__.call_args
         == [("keyid", ), {}])
 
 
@@ -421,7 +421,7 @@ def test_identity_gen_key_if_missing(patches, raises, fingerprint):
         assert not m_data.called
         return
     assert (
-        list(m_gpg.return_value.gen_key.call_args)
+        m_gpg.return_value.gen_key.call_args
         == [(m_data.return_value, ), {}])
 
 
@@ -456,7 +456,7 @@ def test_identity_match(patches, name, email, match, log, gen_key):
             return
         if log:
             assert (
-                list(m_log.return_value.warning.call_args)
+                m_log.return_value.warning.call_args
                 == [(('No GPG name/email supplied, '
                       'signing with first available key'),),
                     {}])
@@ -465,7 +465,7 @@ def test_identity_match(patches, name, email, match, log, gen_key):
             == {'uids': ['UID1', 'UID2'], 'uid': 'UID1'})
         return
     assert (
-        list(m_match.call_args)
+        m_match.call_args
         == [(key["uids"],), {}])
     if log:
         assert not m_log.return_value.warning.called
@@ -494,13 +494,13 @@ def test_identity__match_email(patches, uids, email):
     if email in uids:
         assert result == email
         assert (
-            list(list(c) for c in m_parse.call_args_list)
+            m_parse.call_args_list
             == [[(uid,), {}] for uid in uids[:uids.index(email) + 1]])
         return
 
     assert not result
     assert (
-        list(list(c) for c in m_parse.call_args_list)
+        m_parse.call_args_list
         == [[(uid,), {}] for uid in uids])
 
 
@@ -524,21 +524,21 @@ def test_identity__match_key(patches, name, email):
 
     if name and email:
         assert (
-            list(m_uid.call_args)
+            m_uid.call_args
             == [(dict(uids=key["uids"]),), {}])
         assert not m_email.called
         assert not m_name.called
         assert result == m_uid.return_value
     elif name:
         assert (
-            list(m_name.call_args)
+            m_name.call_args
             == [(dict(uids=key["uids"]),), {}])
         assert not m_email.called
         assert not m_uid.called
         assert result == m_name.return_value
     elif email:
         assert (
-            list(m_email.call_args)
+            m_email.call_args
             == [(dict(uids=key["uids"]),), {}])
         assert not m_name.called
         assert not m_uid.called
@@ -562,13 +562,13 @@ def test_identity__match_name(patches, uids, name):
     if name in uids:
         assert result == name
         assert (
-            list(list(c) for c in m_parse.call_args_list)
+            m_parse.call_args_list
             == [[(uid,), {}] for uid in uids[:uids.index(name) + 1]])
         return
 
     assert not result
     assert (
-        list(list(c) for c in m_parse.call_args_list)
+        m_parse.call_args_list
         == [[(uid,), {}] for uid in uids])
 
 

--- a/envoy.gpg.sign/tests/test_deb.py
+++ b/envoy.gpg.sign/tests/test_deb.py
@@ -30,7 +30,7 @@ def test_changes_dunder_iter(patches):
 
     assert isinstance(result, types.GeneratorType)
     assert (
-        list(path.unlink.call_args)
+        path.unlink.call_args
         == [(), {}])
 
 
@@ -91,9 +91,7 @@ def test_changes_distributions(patches, lines):
         lines = lines[:breakon]
     count = len(lines) + 1
     assert (
-        list(list(c)
-             for c
-             in readline.call_args_list)
+        readline.call_args_list
         == [[(), {}]] * count)
 
 
@@ -112,7 +110,7 @@ def test_changes_files(patches):
 
     assert isinstance(result, types.GeneratorType)
     assert (
-        list(list(c) for c in m_changes.call_args_list)
+        m_changes.call_args_list
         == [[('DISTRO1',), {}],
             [('DISTRO2',), {}],
             [('DISTRO3',), {}]])
@@ -132,16 +130,16 @@ def test_changes_changes_file(patches):
             == m_path.return_value)
 
     assert (
-        list(m_path.call_args)
+        m_path.call_args
         == [('DISTRO',), {}])
     assert (
-        list(m_path.return_value.write_text.call_args)
+        m_path.return_value.write_text.call_args
         == [(path.read_text.return_value.replace.return_value,), {}])
     assert (
-        list(path.read_text.call_args)
+        path.read_text.call_args
         == [(), {}])
     assert (
-        list(path.read_text.return_value.replace.call_args)
+        path.read_text.return_value.replace.call_args
         == [(m_distros.return_value, "DISTRO"), {}])
 
 
@@ -150,7 +148,7 @@ def test_changes_file_path():
     changes = sign.DebChangesFiles(path)
     assert changes.changes_file_path("DISTRO") == path.with_suffix.return_value
     assert (
-        list(path.with_suffix.call_args)
+        path.with_suffix.call_args
         == [('.DISTRO.changes',), {}])
 
 
@@ -200,5 +198,5 @@ def test_debsign_pkg_files(patches):
 
     assert m_chain.from_iterable.called
     assert (
-        list(list(c) for c in m_changes.return_value.call_args_list)
+        m_changes.return_value.call_args_list
         == [[('FILE1',), {}], [('FILE2',), {}], [('FILE3',), {}]])

--- a/envoy.gpg.sign/tests/test_rpm.py
+++ b/envoy.gpg.sign/tests/test_rpm.py
@@ -30,7 +30,7 @@ def test_rpmmacro_home(patches):
         assert rpmmacro.home == m_plib.Path.return_value
 
     assert (
-        list(m_plib.Path.call_args)
+        m_plib.Path.call_args
         == [(rpmmacro._home,), {}])
 
 
@@ -43,7 +43,7 @@ def test_rpmmacro_path(patches):
         assert rpmmacro.path == m_home.return_value.joinpath.return_value
 
     assert (
-        list(m_home.return_value.joinpath.call_args)
+        m_home.return_value.joinpath.call_args
         == [(rpmmacro._macro_filename, ), {}])
 
 
@@ -59,7 +59,7 @@ def test_rpmmacro_macro(patches, kwargs):
     expected = m_template.return_value
     for k, v in kwargs.items():
         assert (
-            list(expected.replace.call_args)
+            expected.replace.call_args
             == [(f"__{k.upper()}__", v), {}])
         expected = expected.replace.return_value
 
@@ -83,7 +83,7 @@ def test_rpmmacro_write(patches, overwrite, exists):
 
     if not overwrite:
         assert (
-            list(m_path.return_value.exists.call_args)
+            m_path.return_value.exists.call_args
             == [(), {}])
     else:
         assert not m_path.return_value.exists.join.called
@@ -93,7 +93,7 @@ def test_rpmmacro_write(patches, overwrite, exists):
         return
 
     assert (
-        list(m_path.return_value.write_text.call_args)
+        m_path.return_value.write_text.call_args
         == [(m_macro.return_value,), {}])
 
 
@@ -116,10 +116,10 @@ def test_rpmsign_constructor(patches, args, kwargs):
     assert rpmsign.ext == "rpm"
     assert rpmsign.command_name == "rpmsign"
     assert (
-        list(m_setup.call_args)
+        m_setup.call_args
         == [(), {}])
     assert (
-        list(m_super.call_args)
+        m_super.call_args
         == [('PATH', maintainer) + args, kwargs])
     assert rpmsign.rpmmacro == sign.RPMMacro
 
@@ -188,7 +188,7 @@ def test_rpmsign_setup(patches):
         assert not rpmsign.setup()
 
     assert (
-        list(m_macro.return_value.call_args)
+        m_macro.return_value.call_args
         == [(maintainer.home,),
             {'maintainer': maintainer.name,
              'gpg_bin': maintainer.gpg_bin,
@@ -208,8 +208,8 @@ def test_rpmsign_sign_pkg(patches):
         assert not rpmsign.sign_pkg(file)
 
     assert (
-        list(file.chmod.call_args)
+        file.chmod.call_args
         == [(0o755, ), {}])
     assert (
-        list(m_sign.call_args)
+        m_sign.call_args
         == [(file,), {}])

--- a/envoy.gpg.sign/tests/test_runner.py
+++ b/envoy.gpg.sign/tests/test_runner.py
@@ -86,7 +86,7 @@ def test_packager_gnupg_home(patches, gen_key):
         assert not m_temp.called
         return
     assert (
-        list(m_plib.Path.call_args)
+        m_plib.Path.call_args
         == [(m_temp.return_value.name, ), {}])
 
 
@@ -124,7 +124,7 @@ def test_packager_maintainer(patches):
         assert packager.maintainer == m_class.return_value.return_value
 
     assert (
-        list(m_class.return_value.call_args)
+        m_class.return_value.call_args
         == [(m_name.return_value,
              m_email.return_value,
              m_log.return_value),
@@ -185,7 +185,7 @@ def test_packager_path(patches):
         assert packager.path == m_plib.Path.return_value
 
     assert (
-        list(m_plib.Path.call_args)
+        m_plib.Path.call_args
         == [(m_args.return_value.path, ), {}])
     assert "path" not in packager.__dict__
 
@@ -216,7 +216,7 @@ def test_packager_add_arguments():
     parser = MagicMock()
     packager.add_arguments(parser)
     assert (
-        list(list(c) for c in parser.add_argument.call_args_list)
+        parser.add_argument.call_args_list
         == [[('--verbosity', '-v'),
              {'choices': ['debug', 'info', 'warn', 'error'],
               'default': 'info',
@@ -271,17 +271,17 @@ def test_packager_add_key(patches):
         assert not packager.add_key(path)
 
     assert (
-        list(m_utils.typed.call_args)
+        m_utils.typed.call_args
         == [(m_plib.Path, path), {}])
     m_path = m_utils.typed.return_value
     assert (
-        list(m_path.joinpath.call_args)
+        m_path.joinpath.call_args
         == [(m_keypath.return_value, ), {}])
     assert (
-        list(m_path.joinpath.return_value.write_text.call_args)
+        m_path.joinpath.return_value.write_text.call_args
         == [(m_maintainer.return_value.export_key.return_value, ), {}])
     assert (
-        list(m_maintainer.return_value.export_key.call_args)
+        m_maintainer.return_value.export_key.call_args
         == [(), {}])
 
 
@@ -297,13 +297,13 @@ def test_packager_archive(patches):
         assert not packager.archive("PATH")
 
     assert (
-        list(m_tarfile.open.call_args)
+        m_tarfile.open.call_args
         == [(m_tar.return_value, m_utils.tar_mode.return_value), {}])
     assert (
-        list(m_utils.tar_mode.call_args)
+        m_utils.tar_mode.call_args
         == [(m_tar.return_value, ), dict(mode="w")])
     assert (
-        list(m_tarfile.open.return_value.__enter__.return_value.add.call_args)
+        m_tarfile.open.return_value.__enter__.return_value.add.call_args
         == [('PATH',), {'arcname': '.'}])
 
 
@@ -325,7 +325,7 @@ async def test_packager_cleanup(patches, indict):
         assert not m_temp.called
         return
     assert (
-        list(m_temp.return_value.cleanup.call_args)
+        m_temp.return_value.cleanup.call_args
         == [(), {}])
 
 
@@ -347,10 +347,10 @@ def test_packager_get_signing_util(patches):
             == m_utils.return_value.__getitem__.return_value.return_value)
 
     assert (
-        list(m_utils.return_value.__getitem__.call_args)
+        m_utils.return_value.__getitem__.call_args
         == [(path.name,), {}])
     assert (
-        list(m_utils.return_value.__getitem__.return_value.call_args)
+        m_utils.return_value.__getitem__.return_value.call_args
         == [(path, m_maintainer.return_value, m_log.return_value), {}])
 
 
@@ -373,18 +373,18 @@ async def test_packager_run(patches, extract):
         assert not await packager.run()
 
     assert (
-        list(m_log.return_value.success.call_args)
+        m_log.return_value.success.call_args
         == [('Successfully signed packages',), {}])
 
     if extract:
         assert (
-            list(m_tarb.call_args)
+            m_tarb.call_args
             == [(), {}])
         assert not m_dir.called
         return
     assert not m_tarb.called
     assert (
-        list(m_dir.call_args)
+        m_dir.call_args
         == [(), {}])
 
 
@@ -401,14 +401,14 @@ def test_packager_sign(patches):
         assert not packager.sign(path)
 
     assert (
-        list(m_log.return_value.notice.call_args)
+        m_log.return_value.notice.call_args
         == [((f"Signing {path.name}s ({m_maintainer.return_value}) "
               f"{path}"),), {}])
     assert (
-        list(m_util.call_args)
+        m_util.call_args
         == [(path, ), {}])
     assert (
-        list(m_util.return_value.sign.call_args)
+        m_util.return_value.sign.call_args
         == [(), {}])
 
 
@@ -435,11 +435,11 @@ def test_packager_sign_all(patches, listdir, utils):
         assert not packager.sign_all(path)
 
     assert (
-        list(path.glob.call_args)
+        path.glob.call_args
         == [('*',), {}])
     expected = [x for x in listdir if x in utils]
     assert (
-        list(list(c) for c in m_sign.call_args_list)
+        m_sign.call_args_list
         == [[(_glob[k], ), {}] for k in expected])
 
 
@@ -458,14 +458,14 @@ def test_packager_sign_directory(patches, tar):
         assert not packager.sign_directory()
 
     assert (
-        list(m_sign.call_args)
+        m_sign.call_args
         == [(m_path.return_value, ), {}])
     if not tar:
         assert not m_archive.called
         return
 
     assert (
-        list(m_archive.call_args)
+        m_archive.call_args
         == [(m_path.return_value, ), {}])
 
 
@@ -501,14 +501,14 @@ def test_packager_sign_tarball(patches, tar):
         return
 
     assert (
-        list(m_utils.untar.call_args)
+        m_utils.untar.call_args
         == [(m_path.return_value,), {}])
     assert (
-        list(m_sign.call_args)
+        m_sign.call_args
         == [(m_utils.untar.return_value.__enter__.return_value,), {}])
     assert (
-        list(m_addkey.call_args)
+        m_addkey.call_args
         == [(m_utils.untar.return_value.__enter__.return_value,), {}])
     assert (
-        list(m_archive.call_args)
+        m_archive.call_args
         == [(m_utils.untar.return_value.__enter__.return_value,), {}])

--- a/envoy.gpg.sign/tests/test_util.py
+++ b/envoy.gpg.sign/tests/test_util.py
@@ -44,7 +44,7 @@ def test_util_command(patches, command_name, command, which):
                 util.command
 
             assert (
-                list(m_shutil.which.call_args)
+                m_shutil.which.call_args
                 == [(command_name or "",), {}])
             assert (
                 e.value.args[0]
@@ -63,7 +63,7 @@ def test_util_command(patches, command_name, command, which):
         return
 
     assert (
-        list(m_shutil.which.call_args)
+        m_shutil.which.call_args
         == [(command_name or "",), {}])
     assert result == m_shutil.which.return_value
 
@@ -82,7 +82,7 @@ def test_util_sign(patches):
         assert not util.sign()
 
     assert (
-        list(list(c) for c in m_sign.call_args_list)
+        m_sign.call_args_list
         == [[('PKG1',), {}],
             [('PKG2',), {}],
             [('PKG3',), {}]])
@@ -127,20 +127,20 @@ def test_util_sign_pkg(patches, returncode):
             assert not util.sign_pkg(pkg_file)
 
     assert (
-        list(util.log.notice.call_args)
+        util.log.notice.call_args
         == [(f"Sign package ({m_type.return_value}): {pkg_file.name}",), {}])
     assert (
-        list(m_command.call_args)
+        m_command.call_args
         == [(pkg_file,), {}])
     assert (
-        list(m_subproc.run.call_args)
+        m_subproc.run.call_args
         == [(m_command.return_value,),
             {'capture_output': True,
              'encoding': 'utf-8'}])
 
     if not returncode:
         assert (
-            list(util.log.success.call_args)
+            util.log.success.call_args
             == [((f"Signed package ({m_type.return_value}): "
                   f"{pkg_file.name}"),), {}])
         return
@@ -172,7 +172,7 @@ def test_util_path(patches):
         assert util.path == m_plib.Path.return_value
 
     assert (
-        list(m_plib.Path.call_args)
+        m_plib.Path.call_args
         == [(util._path,), {}])
 
 
@@ -205,7 +205,7 @@ def test_util_pkg_files(patches, files):
     expected = [fname for fname in files if fname.endswith(".EXT")]
 
     assert (
-        list(m_path.return_value.glob.call_args)
+        m_path.return_value.glob.call_args
         == [("*",), {}])
     assert "pkg_files" not in util.__dict__
     assert (


### PR DESCRIPTION
Fix #185

Signed-off-by: Ryan Northey <ryan@synca.io>