### PR TITLE
`aio.core`: Fix error handling gathering properties in inflate

### DIFF
--- a/aio.core/aio/core/tasks/tasks.py
+++ b/aio.core/aio/core/tasks/tasks.py
@@ -478,10 +478,14 @@ async def inflate(
     things = concurrent(
         (asyncio.gather(
             asyncio.sleep(0, result=thing),
-            *cb(thing))
+            *cb(thing),
+            return_exceptions=True)
          for thing
          in iterable),
         limit=limit,
         yield_exceptions=yield_exceptions)
     async for thing in things:
+        if isinstance(thing[1], Exception):
+            # TODO: test this further, and perhaps respect `yield_exceptions`
+            raise thing[1]
         yield thing[0]

--- a/aio.core/tests/test_task.py
+++ b/aio.core/tests/test_task.py
@@ -1277,7 +1277,8 @@ async def test_inflate(patches, iterable, limit, yield_exceptions):
         == [m_aio.gather.return_value] * len(iterable))
     assert (
         m_aio.gather.call_args_list
-        == [[(m_aio.sleep.return_value, *awaitables), {}]
+        == [[(m_aio.sleep.return_value, *awaitables),
+             dict(return_exceptions=True)]
             for i in range(0, len(iterable))])
     assert (
         m_aio.sleep.call_args_list


### PR DESCRIPTION
Signed-off-by: Ryan Northey <ryan@synca.io>