### PR TITLE
`aio.run.runner`: Fix err handling on `KeyboardInterrupt`

### DIFF
--- a/aio.run.checker/aio/run/checker/checker.py
+++ b/aio.run.checker/aio/run/checker/checker.py
@@ -301,8 +301,8 @@ class Checker(runner.Runner):
             self.summary.print_summary()
         return 1 if self.has_failed else 0
 
-    async def on_runner_error(self, e: BaseException) -> None:
-        await self.on_checks_complete()
+    async def on_runner_error(self, e: BaseException) -> int:
+        return await self.on_checks_complete()
 
     def succeed(self, name: str, success: list, log: bool = True) -> None:
         """Record (and log) success for a check type."""

--- a/aio.run.checker/tests/test_checker.py
+++ b/aio.run.checker/tests/test_checker.py
@@ -685,7 +685,9 @@ async def test_checker_on_runner_error(patches):
     e = MagicMock()
 
     with patched as (m_complete, ):
-        assert not await checker.on_runner_error(e)
+        assert (
+            await checker.on_runner_error(e)
+            == m_complete.return_value)
 
     assert (
         m_complete.call_args


### PR DESCRIPTION
Fix #415

Signed-off-by: Ryan Northey <ryan@synca.io>