### PR TITLE
`envoy.code.check`: Handle `OSCommandError` in preloaders

### DIFF
--- a/envoy.code.check/envoy/code/check/abstract/checker.py
+++ b/envoy.code.check/envoy/code/check/abstract/checker.py
@@ -9,7 +9,7 @@ from typing import Dict, Mapping, Optional, Pattern, Set, Tuple, Type
 
 import abstracts
 
-from aio.core import directory as _directory, event
+from aio.core import directory as _directory, event, subprocess
 from aio.run import checker
 
 from envoy.code.check import abstract, typing
@@ -181,6 +181,7 @@ class ACodeChecker(
         """Check for glint issues."""
         await self._code_check(self.glint)
 
+    # TODO: catch errors in checkers as well as preloaders
     async def check_python_flake8(self) -> None:
         """Check for flake8 issues."""
         await self._code_check(self.flake8)
@@ -194,22 +195,26 @@ class ACodeChecker(
         await self._code_check(self.shellcheck)
 
     @checker.preload(
-        when=["python_flake8"])
+        when=["python_flake8"],
+        catches=[subprocess.exceptions.OSCommandError])
     async def preload_flake8(self) -> None:
         await self.flake8.problem_files
 
     @checker.preload(
-        when=["glint"])
+        when=["glint"],
+        catches=[subprocess.exceptions.OSCommandError])
     async def preload_glint(self) -> None:
         await self.glint.problem_files
 
     @checker.preload(
-        when=["shellcheck"])
+        when=["shellcheck"],
+        catches=[subprocess.exceptions.OSCommandError])
     async def preload_shellcheck(self) -> None:
         await self.shellcheck.problem_files
 
     @checker.preload(
-        when=["python_yapf"])
+        when=["python_yapf"],
+        catches=[subprocess.exceptions.OSCommandError])
     async def preload_yapf(self) -> None:
         await self.yapf.problem_files
 

--- a/envoy.code.check/envoy/code/check/abstract/shellcheck.py
+++ b/envoy.code.check/envoy/code/check/abstract/shellcheck.py
@@ -10,7 +10,7 @@ import abstracts
 from aio.core import subprocess as _subprocess
 from aio.core.functional import async_property
 
-from envoy.code.check import abstract, exceptions, typing
+from envoy.code.check import abstract, typing
 
 
 SHELLCHECK_ERROR_LINE_RE = r"In ([\w\-\_\./]+) line ([0-9]+):"
@@ -188,7 +188,7 @@ class AShellcheckCheck(abstract.ACodeCheck, metaclass=abstracts.Abstraction):
         command = shutil.which("shellcheck")
         if command:
             return command
-        raise exceptions.ShellcheckError(
+        raise _subprocess.exceptions.OSCommandError(
             "Unable to find shellcheck command")
 
     @cached_property

--- a/envoy.code.check/tests/test_abstract_shellcheck.py
+++ b/envoy.code.check/tests/test_abstract_shellcheck.py
@@ -489,7 +489,7 @@ def test_shellcheck_shellcheck_command(patches, command):
     with patched as (m_shutil, ):
         m_shutil.which.return_value = command
         if not command:
-            with pytest.raises(check.exceptions.ShellcheckError) as e:
+            with pytest.raises(subprocess.exceptions.OSCommandError) as e:
                 shellcheck.shellcheck_command
             assert e.value.args[0] == 'Unable to find shellcheck command'
         else:


### PR DESCRIPTION
Signed-off-by: Ryan Northey <ryan@synca.io>