### PR TITLE
packaging: Exclude build/dist folders

### DIFF
--- a/abstracts/setup.cfg
+++ b/abstracts/setup.cfg
@@ -39,3 +39,10 @@ publish = wheel
 
 [options.package_data]
 * = py.typed
+
+[options.packages.find]
+include = abstracts.*
+exclude =
+    build.*
+    tests.*
+    dist.*

--- a/aio.api.bazel/setup.cfg
+++ b/aio.api.bazel/setup.cfg
@@ -43,3 +43,10 @@ publish = wheel
 
 [options.package_data]
 * = py.typed
+
+[options.packages.find]
+include = aio.*
+exclude =
+    build.*
+    tests.*
+    dist.*

--- a/aio.api.github/setup.cfg
+++ b/aio.api.github/setup.cfg
@@ -51,3 +51,10 @@ publish = wheel
 
 [options.package_data]
 * = py.typed
+
+[options.packages.find]
+include = aio.*
+exclude =
+    build.*
+    tests.*
+    dist.*

--- a/aio.api.nist/setup.cfg
+++ b/aio.api.nist/setup.cfg
@@ -49,3 +49,10 @@ publish = wheel
 
 [options.package_data]
 * = py.typed
+
+[options.packages.find]
+include = aio.*
+exclude =
+    build.*
+    tests.*
+    dist.*

--- a/aio.core/setup.cfg
+++ b/aio.core/setup.cfg
@@ -51,3 +51,10 @@ publish = wheel
 
 [options.package_data]
 * = py.typed
+
+[options.packages.find]
+include = aio.*
+exclude =
+    build.*
+    tests.*
+    dist.*

--- a/aio.run.checker/setup.cfg
+++ b/aio.run.checker/setup.cfg
@@ -44,3 +44,10 @@ publish = wheel
 
 [options.package_data]
 * = py.typed
+
+[options.packages.find]
+include = aio.*
+exclude =
+    build.*
+    tests.*
+    dist.*

--- a/aio.run.runner/setup.cfg
+++ b/aio.run.runner/setup.cfg
@@ -50,3 +50,10 @@ publish = wheel
 
 [options.package_data]
 * = py.typed
+
+[options.packages.find]
+include = aio.*
+exclude =
+    build.*
+    tests.*
+    dist.*

--- a/envoy.base.utils/setup.cfg
+++ b/envoy.base.utils/setup.cfg
@@ -64,3 +64,10 @@ publish = wheel
 [options.entry_points]
 console_scripts =
     envoy.project = envoy.base.utils:project_cmd
+
+[options.packages.find]
+include = envoy.*
+exclude =
+    build.*
+    tests.*
+    dist.*

--- a/envoy.code.check/setup.cfg
+++ b/envoy.code.check/setup.cfg
@@ -56,3 +56,10 @@ publish = wheel
 [options.entry_points]
 console_scripts =
     envoy.code.check = envoy.code.check:run
+
+[options.packages.find]
+include = envoy.*
+exclude =
+    build.*
+    tests.*
+    dist.*

--- a/envoy.dependency.check/setup.cfg
+++ b/envoy.dependency.check/setup.cfg
@@ -60,3 +60,10 @@ publish = wheel
 [options.entry_points]
 console_scripts =
     envoy.dependency.check = envoy.dependency.check:run
+
+[options.packages.find]
+include = envoy.*
+exclude =
+    build.*
+    tests.*
+    dist.*

--- a/envoy.dependency.pip_check/setup.cfg
+++ b/envoy.dependency.pip_check/setup.cfg
@@ -49,3 +49,10 @@ publish = wheel
 [options.entry_points]
 console_scripts =
     envoy.dependency.pip_check = envoy.dependency.pip_check:cmd
+
+[options.packages.find]
+include = envoy.*
+exclude =
+    build.*
+    tests.*
+    dist.*

--- a/envoy.distribution.distrotest/setup.cfg
+++ b/envoy.distribution.distrotest/setup.cfg
@@ -48,3 +48,10 @@ publish = wheel
 envoy.distribution.distrotest =
     distrotest.yaml
     distrotest.sh
+
+[options.packages.find]
+include = envoy.*
+exclude =
+    build.*
+    tests.*
+    dist.*

--- a/envoy.distribution.verify/setup.cfg
+++ b/envoy.distribution.verify/setup.cfg
@@ -48,3 +48,10 @@ publish = wheel
 [options.entry_points]
 console_scripts =
     envoy.distribution.verify = envoy.distribution.verify:cmd
+
+[options.packages.find]
+include = envoy.*
+exclude =
+    build.*
+    tests.*
+    dist.*


### PR DESCRIPTION
Also fixes issue where build/lib folders are recursively created
during dev

Signed-off-by: Ryan Northey <ryan@synca.io>