### PR TITLE
`aio.api.bazel`: Fix namespace in tests

### DIFF
--- a/aio.api.bazel/tests/BUILD
+++ b/aio.api.bazel/tests/BUILD
@@ -1,6 +1,6 @@
 
 pytooling_tests(
-    "aio.api.github",
+    "aio.api.bazel",
     dependencies=[
         "//deps:abstracts",
         "//deps:aio.core",

--- a/deps/requirements.txt
+++ b/deps/requirements.txt
@@ -1,4 +1,5 @@
 abstracts>=0.0.12
+aio.api.bazel>=0.0.2
 aio.api.github>=0.1.2
 aio.api.nist>=0.0.2
 aio.core>=0.8.9


### PR DESCRIPTION
Signed-off-by: Ryan Northey <ryan@synca.io>