### PR TITLE
cache pants bootstrap

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
         key: ${{ runner.os }}-${{ hashFiles('pants*toml') }}
         path: ~/.cache/pants/setup
     - name: Run pants (type) check
-      run: "./pants check ::"
+      run: "./pants check $(./pants roots | tr '\n' ',' | sed  's/,/:: /g' -)"
 
   docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
     - main
+    - pants
   pull_request:
     branches:
     - main
@@ -14,12 +15,16 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    if: github.repository_owner == 'envoyproxy'
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4
       with:
         python-version: "3.10"
+    - name: Cache pants
+      uses: actions/cache@v3
+      with:
+        key: ${{ runner.os }}-${{ hashFiles('pants*toml') }}
+        path: ~/.cache/pants/setup
     - name: Run pants test
       run: "./pants test ::"
     - name: Archive code coverage results
@@ -35,6 +40,11 @@ jobs:
     - uses: actions/setup-python@v4
       with:
         python-version: "3.10"
+    - name: Cache pants
+      uses: actions/cache@v3
+      with:
+        key: ${{ runner.os }}-${{ hashFiles('pants*toml') }}
+        path: ~/.cache/pants/setup
     - name: Run pants lint
       run: "./pants lint ::"
 
@@ -45,8 +55,13 @@ jobs:
     - uses: actions/setup-python@v4
       with:
         python-version: "3.10"
+    - name: Cache pants
+      uses: actions/cache@v3
+      with:
+        key: ${{ runner.os }}-${{ hashFiles('pants*toml') }}
+        path: ~/.cache/pants/setup
     - name: Run pants (type) check
-      run: "./pants check $(./pants roots | tr '\n' ',' | sed  's/,/:: /g' -)"
+      run: "./pants check ::"
 
   docs:
     runs-on: ubuntu-latest
@@ -55,6 +70,11 @@ jobs:
     - uses: actions/setup-python@v4
       with:
         python-version: "3.10"
+    - name: Cache pants
+      uses: actions/cache@v3
+      with:
+        key: ${{ runner.os }}-${{ hashFiles('pants*toml') }}
+        path: ~/.cache/pants/setup
     - name: Run pants README
       run: "./pants readme --check=README.md ::"
 
@@ -70,6 +90,11 @@ jobs:
     - uses: actions/setup-python@v4
       with:
         python-version: "3.10"
+    - name: Cache pants
+      uses: actions/cache@v3
+      with:
+        key: ${{ runner.os }}-${{ hashFiles('pants*toml') }}
+        path: ~/.cache/pants/setup
     - name: Run pants package
       run: "./pants package ::"
     - name: Archive created packages

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
     - main
-    - pants
   pull_request:
     branches:
     - main
@@ -15,6 +14,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'envoyproxy'
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4


### PR DESCRIPTION
this caches the directory pants bootstraps itself into which will make subsequent runs of GHA not require the somewhat time consuming step of bootstrapping pants.

https://www.pantsbuild.org/docs/using-pants-in-ci#directories-to-cache
you can see it here:  https://github.com/asherf/pytooling/runs/7697601505?check_suite_focus=true
![Screen Shot 2022-08-05 at 3 28 39 PM](https://user-images.githubusercontent.com/1268088/183147575-f1ff3873-c422-4922-a49e-ce8369d8bdbe.png)
