### PR TITLE
envoy.code.check: skip checking the go files.

### DIFF
--- a/envoy.code.check/envoy/code/check/abstract/glint.py
+++ b/envoy.code.check/envoy/code/check/abstract/glint.py
@@ -18,6 +18,7 @@ from envoy.code.check import abstract, interface, typing
 
 
 NOGLINT_RE = (
+    r"[\w\W/-]*\.go$",
     r"[\w\W/-]*\.patch$",
     r"^test/[\w/]*_corpus/[\w/]*",
     r"^tools/[\w/]*_corpus/[\w/]*",


### PR DESCRIPTION
instead, using gofmt in envoy ci.
refer: https://github.com/envoyproxy/envoy/pull/24819

Signed-off-by: doujiang24 <doujiang24@gmail.com>