### PR TITLE
Revert "build(deps): bump types-docutils in /deps"

### DIFF
--- a/deps/requirements.txt
+++ b/deps/requirements.txt
@@ -64,7 +64,7 @@ yarl>=1.7.2
 zstandard
 
 types-aiofiles
-types-docutils==0.22.3.20251115
+types-docutils==0.21.0.20250715
 types-frozendict
 types-orjson
 types-protobuf


### PR DESCRIPTION
This reverts commit 93bed61f899f3a25dd2a16388866252dbb1f60c2.

this shouldnt have been updated without docutils being updated