### PR TITLE
python/publishing: Disable PyPI attestations temporarily

### DIFF
--- a/actions/python/release/publish/action.yml
+++ b/actions/python/release/publish/action.yml
@@ -6,7 +6,7 @@ description: >-
 inputs:
   attestations:
     type: boolean
-    default: true
+    default: false
   dry-run:
     type: boolean
     default: true


### PR DESCRIPTION
they are not currently compatible with reusable workflows