### PR TITLE
python: Update pytest/mypy packages

### DIFF
--- a/py/mypy-abstracts/setup.cfg
+++ b/py/mypy-abstracts/setup.cfg
@@ -12,14 +12,16 @@ long_description = file: README.rst
 classifiers =
     Development Status :: 4 - Beta
     Intended Audience :: Developers
-    Topic :: Software Development :: Quality Assurance
+    License :: OSI Approved :: Apache Software License
+    Operating System :: OS Independent
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.12
     Programming Language :: Python :: 3 :: Only
+    Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
     Programming Language :: Python :: Implementation :: CPython
-    Operating System :: OS Independent
-    License :: OSI Approved :: Apache Software License
+    Topic :: Software Development :: Quality Assurance
+    Typing :: Typed
 
 [options]
 python_requires = >=3.12

--- a/py/pytest-abstracts/pytest_abstracts/__init__.py
+++ b/py/pytest-abstracts/pytest_abstracts/__init__.py
@@ -1,7 +1,7 @@
 
 import inspect
+from collections.abc import Callable
 from functools import cached_property
-from typing import Callable
 from unittest.mock import MagicMock
 
 import pytest  # type:ignore

--- a/py/pytest-abstracts/setup.cfg
+++ b/py/pytest-abstracts/setup.cfg
@@ -6,27 +6,27 @@ author_email = ryan@synca.io
 maintainer = Ryan Northey
 maintainer_email = ryan@synca.io
 license = Apache Software License 2.0
-url = https://github.com/envoyproxy/toolshed/tree/main/pytest-abstracts
-description = A contextmanager pytest fixture for handling multiple mock abstracts
+url = https://github.com/envoyproxy/toolshed/tree/main/py/pytest-abstracts
+description = A pytest fixture for testing abstract interface implementations
 long_description = file: README.rst
 classifiers =
     Development Status :: 4 - Beta
     Framework :: Pytest
     Intended Audience :: Developers
-    Topic :: Software Development :: Testing
+    License :: OSI Approved :: Apache Software License
+    Operating System :: OS Independent
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.8
-    Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3 :: Only
+    Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
     Programming Language :: Python :: Implementation :: CPython
-    Operating System :: OS Independent
-    License :: OSI Approved :: Apache Software License
+    Topic :: Software Development :: Testing
+    Typing :: Typed
 
 [options]
-python_requires = >=3.5
+python_requires = >=3.12
 packages = find:
-py_modules = pytest_abstracts
 install_requires =
     pytest>=3.5.0
     abstracts
@@ -37,6 +37,18 @@ test =
 lint = flake8
 types = mypy
 publish = wheel
+
+[options.package_data]
+pytest_abstracts = py.typed
+
+[options.packages.find]
+include =
+    pytest_abstracts
+    pytest_abstracts.*
+exclude =
+    build.*
+    tests.*
+    dist.*
 
 [options.entry_points]
 pytest11 =

--- a/py/pytest-iters/pytest_iters/__init__.py
+++ b/py/pytest-iters/pytest_iters/__init__.py
@@ -1,19 +1,18 @@
-from typing import (
-    Any, Callable, Dict, Iterable, List,
-    Optional, Set, Tuple, Type, Union)
+from collections.abc import Callable, Iterable
+from typing import Any
 
 import pytest  # type:ignore
 
 
-def _dict_item(x: int) -> Tuple[str, str]:
+def _dict_item(x: int) -> tuple[str, str]:
     return f"K{x}", f"V{x}"
 
 
 def _iters_mapping(
-        sequence: Type[Dict],
+        sequence: type[dict],
         count: int,
         start: int,
-        cb: Optional[Callable[[int], Any]] = None) -> Iterable:
+        cb: Callable[[int], Any] | None = None) -> Iterable:
     return sequence(
         (cb or _dict_item)(x)
         for x
@@ -25,11 +24,11 @@ def _item(x: int) -> str:
 
 
 def _iters(
-        sequence: Type[Union[Dict, List, Tuple, Set]] = list,
+        sequence: type[dict | list | tuple | set] = list,
         count: int = 5,
         start: int = 0,
-        cb: Optional[Callable[[int], Any]] = None) -> Iterable:
-    if issubclass(sequence, Dict):
+        cb: Callable[[int], Any] | None = None) -> Iterable:
+    if issubclass(sequence, dict):
         return _iters_mapping(sequence, count, start, cb)
     return sequence(
         (cb or _item)(x)

--- a/py/pytest-iters/setup.cfg
+++ b/py/pytest-iters/setup.cfg
@@ -13,14 +13,16 @@ classifiers =
     Development Status :: 4 - Beta
     Framework :: Pytest
     Intended Audience :: Developers
-    Topic :: Software Development :: Testing
+    License :: OSI Approved :: Apache Software License
+    Operating System :: OS Independent
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.12
     Programming Language :: Python :: 3 :: Only
+    Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
     Programming Language :: Python :: Implementation :: CPython
-    Operating System :: OS Independent
-    License :: OSI Approved :: Apache Software License
+    Topic :: Software Development :: Testing
+    Typing :: Typed
 
 [options]
 python_requires = >=3.12

--- a/py/pytest-patches/pytest_patches/__init__.py
+++ b/py/pytest-patches/pytest_patches/__init__.py
@@ -1,5 +1,5 @@
-from contextlib import contextmanager, ExitStack
-from typing import Callable, ContextManager, Iterator
+from collections.abc import Callable, Iterator
+from contextlib import AbstractContextManager, contextmanager, ExitStack
 from unittest.mock import patch
 
 import pytest  # type:ignore
@@ -11,7 +11,7 @@ def nested(*contexts) -> Iterator[tuple]:
         yield tuple(stack.enter_context(context) for context in contexts)
 
 
-def _patches(*args: str, prefix: str = "") -> ContextManager[tuple]:
+def _patches(*args: str, prefix: str = "") -> AbstractContextManager[tuple]:
     """Takes a list of module/class paths to patch and an optional prefix.
 
     The prefix is used to prefix all of the paths
@@ -32,5 +32,5 @@ def _patches(*args: str, prefix: str = "") -> ContextManager[tuple]:
 
 
 @pytest.fixture
-def patches() -> Callable[..., ContextManager[tuple]]:
+def patches() -> Callable[..., AbstractContextManager[tuple]]:
     return _patches

--- a/py/pytest-patches/setup.cfg
+++ b/py/pytest-patches/setup.cfg
@@ -13,14 +13,16 @@ classifiers =
     Development Status :: 4 - Beta
     Framework :: Pytest
     Intended Audience :: Developers
-    Topic :: Software Development :: Testing
+    License :: OSI Approved :: Apache Software License
+    Operating System :: OS Independent
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.12
     Programming Language :: Python :: 3 :: Only
+    Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
     Programming Language :: Python :: Implementation :: CPython
-    Operating System :: OS Independent
-    License :: OSI Approved :: Apache Software License
+    Topic :: Software Development :: Testing
+    Typing :: Typed
 
 [options]
 python_requires = >=3.12


### PR DESCRIPTION
use Python 3.12+ syntax

cleanup package metadata