### PR TITLE
py/`aio.api.bazel`: Cleanup

### DIFF
--- a/py/aio.api.bazel/aio/api/bazel/interface.py
+++ b/py/aio.api.bazel/aio/api/bazel/interface.py
@@ -1,6 +1,7 @@
 
 import sys
-from typing import Any, Awaitable, Callable, TextIO
+from collections.abc import Awaitable, Callable
+from typing import Any, TextIO
 
 import abstracts
 

--- a/py/aio.api.bazel/setup.cfg
+++ b/py/aio.api.bazel/setup.cfg
@@ -1,31 +1,30 @@
 [metadata]
-name = aio_api_bazel
+name = aio.api.bazel
 version = file: VERSION
 author = Ryan Northey
 author_email = ryan@synca.io
 maintainer = Ryan Northey
 maintainer_email = ryan@synca.io
 license = Apache Software License 2.0
-url = https://bazel.com/envoyproxy/toolshed/tree/main/aio.api.bazel
+url = https://github.com/envoyproxy/toolshed/tree/main/py/aio.api.bazel
 description = Async wrapper around bazel
 long_description = file: README.rst
 classifiers =
     Development Status :: 4 - Beta
-    Framework :: Pytest
     Intended Audience :: Developers
-    Topic :: Software Development :: Testing
+    License :: OSI Approved :: Apache Software License
+    Operating System :: OS Independent
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.8
-    Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3 :: Only
+    Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
     Programming Language :: Python :: Implementation :: CPython
-    Operating System :: OS Independent
-    License :: OSI Approved :: Apache Software License
+    Topic :: Software Development
+    Typing :: Typed
 
 [options]
-python_requires = >=3.8
-py_modules = aio.api.bazel
+python_requires = >=3.12
 packages = find_namespace:
 install_requires =
     abstracts>=0.2.0
@@ -34,24 +33,22 @@ install_requires =
 
 [options.extras_require]
 test =
-    pytest
-    pytest-asyncio
+    pytest>=7.4.0
+    pytest-asyncio>=0.23.3
     pytest-coverage
     pytest-patches>=0.1.0
-lint = flake8
+lint = flake8>=6.1.0
 types =
-    mypy
-publish = wheel
+    mypy>=1.6.0
+publish = wheel>=0.41.0
 
 [options.package_data]
-* = py.typed
+aio.api.bazel = py.typed
 
 [options.packages.find]
-include = aio.*
-exclude =
-    build.*
-    tests.*
-    dist.*
+include =
+    aio.api.bazel
+    aio.api.bazel.*
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
packaging
typing
dependency bounds