### PR TITLE
registry: Bump dd-trace-cpp 2.0.0 → 2.1.0

### DIFF
--- a/bazel-registry/modules/dd-trace-cpp/2.1.0.envoy/MODULE.bazel
+++ b/bazel-registry/modules/dd-trace-cpp/2.1.0.envoy/MODULE.bazel
@@ -1,0 +1,10 @@
+module(
+    name = "dd-trace-cpp",
+    version = "2.1.0.envoy",
+    compatibility_level = 0,
+)
+
+bazel_dep(name = "abseil-cpp", version = "20250814.1", repo_name = "com_google_absl")
+bazel_dep(name = "bazel_skylib", version = "1.9.0")
+bazel_dep(name = "platforms", version = "1.0.0")
+bazel_dep(name = "rules_cc", version = "0.2.16")

--- a/bazel-registry/modules/dd-trace-cpp/2.1.0.envoy/presubmit.yml
+++ b/bazel-registry/modules/dd-trace-cpp/2.1.0.envoy/presubmit.yml
@@ -1,0 +1,15 @@
+matrix:
+  platform:
+  - debian11
+  - ubuntu2404
+  - macos
+  bazel:
+  - 8.x
+
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - "@dd-trace-cpp//..."

--- a/bazel-registry/modules/dd-trace-cpp/2.1.0.envoy/source.json
+++ b/bazel-registry/modules/dd-trace-cpp/2.1.0.envoy/source.json
@@ -1,0 +1,5 @@
+{
+    "url": "https://github.com/DataDog/dd-trace-cpp/archive/v2.1.0.tar.gz",
+    "integrity": "sha256-gVL7aeYVGKW1XsuW7cuxlYX4lQtvBwrJjr0LbdYXdJI=",
+    "strip_prefix": "dd-trace-cpp-2.1.0"
+}

--- a/bazel-registry/modules/dd-trace-cpp/metadata.json
+++ b/bazel-registry/modules/dd-trace-cpp/metadata.json
@@ -5,7 +5,8 @@
         "github:DataDog/dd-trace-cpp"
     ],
     "versions": [
-        "2.0.0.envoy"
+        "2.0.0.envoy",
+        "2.1.0.envoy"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
Match version used in envoyproxy/envoy main branch.