### PR TITLE
registry: Fix dlb 8.8.0 integrity hash

### DIFF
--- a/bazel-registry/modules/dlb/8.8.0.envoy/source.json
+++ b/bazel-registry/modules/dlb/8.8.0.envoy/source.json
@@ -1,6 +1,6 @@
 {
     "url": "https://downloadmirror.intel.com/819078/dlb_linux_src_release_8.8.0.txz",
-    "integrity": "sha256-VkU0JU7zK/7VbgpGTFP8oJB+RGswkpwlMhDiw9beWLk=",
+    "integrity": "sha256-35c9MmINjUFejxelgWkXQLWjn8itlQ5Sn9KOIBAyW+k=",
     "strip_prefix": "dlb",
     "overlay": {
         "BUILD.bazel": "sha256-knK3FALbeFkIAoUnjjvNnrVcLZNoSPHekSAUaJx+Vok="


### PR DESCRIPTION
Upstream tarball was regenerated, causing the SHA256 to change. Update to match the current download.