### PR TITLE
actions/pr: Auto-delete head branch after PR merge

### DIFF
--- a/actions/github/pr/action.yml
+++ b/actions/github/pr/action.yml
@@ -32,6 +32,9 @@ inputs:
   diff-show:
     type: boolean
     default: false
+  delete-branch:
+    type: boolean
+    default: true
   dry-run:
     type: boolean
     default: false
@@ -47,6 +50,7 @@ inputs:
       export PR_COMMITTER_EMAIL='\($committer_email)'
       export PR_COMMITTER_NAME='\($committer_name)'
       export PR_COMMIT_MESSAGE='\($commit_message)'
+      export PR_DELETE_BRANCH='\(.delete_branch)'
       cd \(.working_directory)
       ${PR_ACTION_PATH}/create.sh
   wip:
@@ -73,6 +77,7 @@ runs:
         committer_name: ${{ inputs.committer-name }}
         committer_email: ${{ inputs.committer-email }}
         commit_message: ${{ toJSON(inputs.commit-message) }}
+        delete_branch: ${{ inputs.delete-branch }}
         dry_run: ${{ inputs.dry-run }}
         title: ${{ toJSON(inputs.title) }}
         working_directory: ${{ inputs.working-directory }}

--- a/actions/github/pr/create.sh
+++ b/actions/github/pr/create.sh
@@ -25,8 +25,15 @@ PR_BODY="${PR_BODY}
 ${SIGNOFF}"
 
 git push --no-verify --set-upstream origin "$PR_BRANCH"
+
+DELETE_BRANCH_FLAG=()
+if [[ "$PR_DELETE_BRANCH" == "true" ]]; then
+    DELETE_BRANCH_FLAG=(--delete-branch)
+fi
+
 gh pr create \
   -B "$PR_BASE" \
   -H  "$PR_BRANCH" \
+  "${DELETE_BRANCH_FLAG[@]}" \
   --title "$PR_TITLE" \
   --body "$PR_BODY"

--- a/actions/github/pr/tests/no-delete-branch.test.yml
+++ b/actions/github/pr/tests/no-delete-branch.test.yml
@@ -1,0 +1,39 @@
+uses: ./actions/github/pr
+id: pr
+with:
+  base: main
+  branch: ${{ env.TEST_BRANCH }}
+  title: ${{ env.TEST_TITLE }}
+  body: ${{ env.TEST_BODY }}
+  commit: true
+  committer-name: ${{ env.TEST_COMMITTER_NAME }}
+  committer-email: ${{ env.TEST_COMMITTER_EMAIL }}
+  commit-message: ${{ env.TEST_COMMIT_MESSAGE }}
+  delete-branch: false
+  GITHUB_TOKEN: "VERYSECRET"
+
+before:
+- shell: bash
+  env:
+    TEST_BODY: This PR tests no delete-branch functionality
+    TEST_BRANCH: test/pr-action-no-delete-branch
+    TEST_COMMIT_MESSAGE: >-
+      chore: Test no-delete-branch from action
+    TEST_COMMITTER_EMAIL: bot@example.com
+    TEST_COMMITTER_NAME: PR Bot
+    TEST_TITLE: Test PR without delete-branch
+  run: |
+    . "${ACTION_TEST_PATH}/test_fun.sh"
+    setup_test
+
+after:
+- shell: bash
+  run: |
+    . "${ACTION_TEST_PATH}/test_fun.sh"
+    test_no_delete_branch_output_log \
+        "${TEST_COMMITTER_NAME}" \
+        "${TEST_COMMITTER_EMAIL}" \
+        "${TEST_COMMIT_MESSAGE}" \
+        "${TEST_BRANCH}" \
+        "${TEST_TITLE}" \
+        "${TEST_BODY}"

--- a/actions/github/pr/tests/test_fun.sh
+++ b/actions/github/pr/tests/test_fun.sh
@@ -15,7 +15,7 @@ git config --global user.email ${committer_email}
 git commit . -m "${commit_message}" --signoff
 git log -1 --pretty=%B
 git push --no-verify --set-upstream origin ${branch}
-gh pr create -B main -H ${branch} --title "${title}" --body "${body}
+gh pr create -B main -H ${branch} --delete-branch --title "${title}" --body "${body}
 
 
 Signed-off-by: Mock User <mock@example.com>"
@@ -40,7 +40,7 @@ git checkout -b ${branch}
 git commit . -m "${commit_message}" --signoff
 git log -1 --pretty=%B
 git push --no-verify --set-upstream origin ${branch}
-gh pr create -B main -H ${branch} --title "${title}" --body "${body}
+gh pr create -B main -H ${branch} --delete-branch --title "${title}" --body "${body}
 
 
 Signed-off-by: Mock User <mock@example.com>"
@@ -62,6 +62,33 @@ test_nocommit_output_log () {
     local body="$6"
     cat << EOF > /tmp/output.log
 git checkout -b ${branch}
+git log -1 --pretty=%B
+git push --no-verify --set-upstream origin ${branch}
+gh pr create -B main -H ${branch} --delete-branch --title "${title}" --body "${body}
+
+
+Signed-off-by: Mock User <mock@example.com>"
+EOF
+    cmp -s /tmp/output.log "$MOCK_LOG" || {
+        echo "fail:Output does not match" >> "$TEST_OUTPUT"
+        diff -u /tmp/output.log "$MOCK_LOG"
+        return
+    }
+    echo "success:Output matches" >> "$TEST_OUTPUT"
+}
+
+test_no_delete_branch_output_log () {
+    local committer_name="$1"
+    local committer_email="$2"
+    local commit_message="$3"
+    local branch="$4"
+    local title="$5"
+    local body="$6"
+    cat << EOF > /tmp/output.log
+git checkout -b ${branch}
+git config --global user.name "${committer_name}"
+git config --global user.email ${committer_email}
+git commit . -m "${commit_message}" --signoff
 git log -1 --pretty=%B
 git push --no-verify --set-upstream origin ${branch}
 gh pr create -B main -H ${branch} --title "${title}" --body "${body}


### PR DESCRIPTION
Add `--delete-branch` to `gh pr create` so that head branches are automatically deleted when the PR is merged.