### PR TITLE
fix: handle empty files in last_n_bytes_of

### DIFF
--- a/py/envoy.base.utils/envoy/base/utils/utils.py
+++ b/py/envoy.base.utils/envoy/base/utils/utils.py
@@ -139,7 +139,8 @@ def last_n_bytes_of(target: str | pathlib.Path, n: int = 1) -> bytes:
     """Return the last `n` bytes from a file, defaults to 1 byte."""
     with open(target, "rb") as f:
         f.seek(0, os.SEEK_END)
-        f.seek(f.tell() - n)
+        # Clamp to the start of the file so empty or short files do not raise on negative seek.
+        f.seek(max(f.tell() - n, 0))
         return f.read(n)
 
 

--- a/py/envoy.base.utils/tests/test_utils.py
+++ b/py/envoy.base.utils/tests/test_utils.py
@@ -1,4 +1,5 @@
 import pathlib
+import tempfile
 from unittest.mock import MagicMock
 
 import pytest
@@ -271,13 +272,18 @@ def test_last_n_bytes_of(patches, n):
     assert (
         m_open.return_value.__enter__.return_value.seek.call_args_list
         == [[(0, m_os.SEEK_END), {}],
-            [(23 - (n or 1), ), {}]])
+            [(max(23 - (n or 1), 0), ), {}]])
     assert (
         m_open.return_value.__enter__.return_value.tell.call_args
         == [(), {}])
     assert (
         m_open.return_value.__enter__.return_value.read.call_args
         == [(n or 1, ), {}])
+
+
+def test_last_n_bytes_of_empty_file():
+    with tempfile.NamedTemporaryFile() as f:
+        assert utils.last_n_bytes_of(f.name) == b""
 
 
 def test_minor_version_for(patches):


### PR DESCRIPTION
Bug

`glint` checks the final newline through `envoy.base.utils.last_n_bytes_of()`.
On a 0-byte file that helper does a negative seek and blows up with `OSError: [Errno 22] Invalid argument`, so the check crashes instead of flagging the file. Empty files are normal repo inputs, so this edge case is pretty legit.

Fix

Clamp the seek offset to `0`. Empty and short files now return the available tail bytes, nice and boring.

Repro

Before this change:

```bash
python - <<'PY'
from pathlib import Path
from tempfile import TemporaryDirectory
from envoy.code.check.abstract.glint import NewlineChecker

with TemporaryDirectory() as tmp:
    root = Path(tmp)
    empty = root / "empty.txt"
    empty.write_bytes(b"")
    print(NewlineChecker(root).no_newlines([empty.name]))
PY
```

This raised `OSError: [Errno 22] Invalid argument`.

After this change the same snippet returns `{'empty.txt'}`.

Checks

`pytest -q py/envoy.base.utils/tests/test_utils.py -k 'last_n_bytes_of or ellipsize or is_sha'`
`pytest -q py/envoy.code.check/tests/test_abstract_glint.py -k 'newline_checker_no_newlines or glint_no_newlines or files_with_no_newline'`
