### PR TITLE
bazel-registry: bump 4 modules to match envoy main

### DIFF
--- a/bazel-registry/modules/aws-c-auth-testdata/0.10.4.envoy/MODULE.bazel
+++ b/bazel-registry/modules/aws-c-auth-testdata/0.10.4.envoy/MODULE.bazel
@@ -1,0 +1,7 @@
+"""AWS SigV4/SigV4A signing test suite data from aws-c-auth."""
+
+module(
+    name = "aws-c-auth-testdata",
+    version = "0.10.4.envoy",
+    compatibility_level = 1,
+)

--- a/bazel-registry/modules/aws-c-auth-testdata/0.10.4.envoy/overlay/BUILD.bazel
+++ b/bazel-registry/modules/aws-c-auth-testdata/0.10.4.envoy/overlay/BUILD.bazel
@@ -1,0 +1,25 @@
+"""AWS SigV4/SigV4A signing test corpus from aws-c-auth.
+
+This module provides only the test data files from aws-c-auth,
+not the library itself. Used by Envoy's signing implementation tests.
+"""
+
+licenses(["notice"])  # Apache 2
+
+# Test data for sigv4 signer corpus tests
+filegroup(
+    name = "sigv4_tests",
+    srcs = glob(
+        ["tests/aws-signing-test-suite/v4/**"],
+    ),
+    visibility = ["//visibility:public"],
+)
+
+# Test data for sigv4a signer corpus tests
+filegroup(
+    name = "sigv4a_tests",
+    srcs = glob(
+        ["tests/aws-signing-test-suite/v4a/**"],
+    ),
+    visibility = ["//visibility:public"],
+)

--- a/bazel-registry/modules/aws-c-auth-testdata/0.10.4.envoy/presubmit.yml
+++ b/bazel-registry/modules/aws-c-auth-testdata/0.10.4.envoy/presubmit.yml
@@ -1,0 +1,17 @@
+matrix:
+  platform:
+  - debian11
+  - ubuntu2204
+  - macos
+  - macos_arm64
+  bazel:
+  - 8.x
+  - 7.x
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@aws-c-auth-testdata//:sigv4_tests'
+    - '@aws-c-auth-testdata//:sigv4a_tests'

--- a/bazel-registry/modules/aws-c-auth-testdata/0.10.4.envoy/source.json
+++ b/bazel-registry/modules/aws-c-auth-testdata/0.10.4.envoy/source.json
@@ -1,0 +1,8 @@
+{
+    "url": "https://github.com/awslabs/aws-c-auth/archive/refs/tags/v0.10.4.tar.gz",
+    "integrity": "sha256-b7Vn9JakUNS20/V0nXNZd6AVaVfozLypr3pe4V0f/ac=",
+    "strip_prefix": "aws-c-auth-0.10.4",
+    "overlay": {
+        "BUILD.bazel": "sha256-fYbkvIxTSZ5V/GTV0fA1TuNi0evkMC2uRmxJk3izPok="
+    }
+}

--- a/bazel-registry/modules/aws-c-auth-testdata/metadata.json
+++ b/bazel-registry/modules/aws-c-auth-testdata/metadata.json
@@ -11,7 +11,8 @@
         "github:awslabs/aws-c-auth"
     ],
     "versions": [
-        "0.9.5.envoy"
+        "0.9.5.envoy",
+        "0.10.4.envoy"
     ],
     "yanked_versions": {}
 }

--- a/bazel-registry/modules/dd-trace-cpp/2.1.1.envoy/MODULE.bazel
+++ b/bazel-registry/modules/dd-trace-cpp/2.1.1.envoy/MODULE.bazel
@@ -1,0 +1,10 @@
+module(
+    name = "dd-trace-cpp",
+    version = "2.1.1.envoy",
+    compatibility_level = 0,
+)
+
+bazel_dep(name = "abseil-cpp", version = "20250814.1", repo_name = "com_google_absl")
+bazel_dep(name = "bazel_skylib", version = "1.9.0")
+bazel_dep(name = "platforms", version = "1.0.0")
+bazel_dep(name = "rules_cc", version = "0.2.16")

--- a/bazel-registry/modules/dd-trace-cpp/2.1.1.envoy/presubmit.yml
+++ b/bazel-registry/modules/dd-trace-cpp/2.1.1.envoy/presubmit.yml
@@ -1,0 +1,15 @@
+matrix:
+  platform:
+  - debian11
+  - ubuntu2404
+  - macos
+  bazel:
+  - 8.x
+
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - "@dd-trace-cpp//..."

--- a/bazel-registry/modules/dd-trace-cpp/2.1.1.envoy/source.json
+++ b/bazel-registry/modules/dd-trace-cpp/2.1.1.envoy/source.json
@@ -1,0 +1,5 @@
+{
+    "url": "https://github.com/DataDog/dd-trace-cpp/archive/v2.1.1.tar.gz",
+    "integrity": "sha256-Po0qEsQ0t2asksH87Af0m5K4oSkC+X5sVIOaZavkRkk=",
+    "strip_prefix": "dd-trace-cpp-2.1.1"
+}

--- a/bazel-registry/modules/dd-trace-cpp/metadata.json
+++ b/bazel-registry/modules/dd-trace-cpp/metadata.json
@@ -5,7 +5,8 @@
         "github:DataDog/dd-trace-cpp"
     ],
     "versions": [
-        "2.0.0.envoy"
+        "2.0.0.envoy",
+        "2.1.1.envoy"
     ],
     "yanked_versions": {}
 }

--- a/bazel-registry/modules/kafka_message/3.9.2.envoy/MODULE.bazel
+++ b/bazel-registry/modules/kafka_message/3.9.2.envoy/MODULE.bazel
@@ -1,0 +1,8 @@
+"""Kafka protocol message definitions from Apache Kafka."""
+
+module(
+    name = "kafka_message",
+    version = "3.9.2.envoy",
+    bazel_compatibility = [">=7.2.1"],
+    compatibility_level = 1,
+)

--- a/bazel-registry/modules/kafka_message/3.9.2.envoy/overlay/BUILD.bazel
+++ b/bazel-registry/modules/kafka_message/3.9.2.envoy/overlay/BUILD.bazel
@@ -1,0 +1,28 @@
+"""Kafka protocol message definitions.
+
+This module provides Kafka protocol message definitions (JSON files) from Apache Kafka.
+Used by Envoy's Kafka filter for protocol message parsing and code generation.
+"""
+
+licenses(["notice"])  # Apache 2.0
+
+# Kafka protocol request message definitions
+filegroup(
+    name = "request_protocol_files",
+    srcs = glob(["*Request.json"]),
+    visibility = ["//visibility:public"],
+)
+
+# Kafka protocol response message definitions
+filegroup(
+    name = "response_protocol_files",
+    srcs = glob(["*Response.json"]),
+    visibility = ["//visibility:public"],
+)
+
+# All Kafka protocol message definitions
+filegroup(
+    name = "all_protocol_files",
+    srcs = glob(["*.json"]),
+    visibility = ["//visibility:public"],
+)

--- a/bazel-registry/modules/kafka_message/3.9.2.envoy/presubmit.yml
+++ b/bazel-registry/modules/kafka_message/3.9.2.envoy/presubmit.yml
@@ -1,0 +1,19 @@
+matrix:
+  platform:
+  - debian11
+  - debian10
+  - ubuntu2004
+  - ubuntu2204
+  - macos
+  bazel:
+  - 8.x
+  - 7.x
+tasks:
+  verify_targets:
+    name: Verify kafka_message protocol files
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@kafka_message//:request_protocol_files'
+    - '@kafka_message//:response_protocol_files'
+    - '@kafka_message//:all_protocol_files'

--- a/bazel-registry/modules/kafka_message/3.9.2.envoy/source.json
+++ b/bazel-registry/modules/kafka_message/3.9.2.envoy/source.json
@@ -1,0 +1,8 @@
+{
+    "url": "https://github.com/apache/kafka/archive/3.9.2.zip",
+    "integrity": "sha256-CFu+6CCP6m0csiSYr6b/w4NQN1FmQyCPcFQgVktJuA4=",
+    "strip_prefix": "kafka-3.9.2/clients/src/main/resources/common/message",
+    "overlay": {
+        "BUILD.bazel": "sha256-4l4zD8+GCfZlGeAE7pmPvhbmQNZNviJOcqxVO1m7zG8="
+    }
+}

--- a/bazel-registry/modules/kafka_message/metadata.json
+++ b/bazel-registry/modules/kafka_message/metadata.json
@@ -11,7 +11,8 @@
         "github:apache/kafka"
     ],
     "versions": [
-        "3.9.1.envoy"
+        "3.9.1.envoy",
+        "3.9.2.envoy"
     ],
     "yanked_versions": {}
 }

--- a/bazel-registry/modules/skywalking-data-collect-protocol/10.4.0.envoy/MODULE.bazel
+++ b/bazel-registry/modules/skywalking-data-collect-protocol/10.4.0.envoy/MODULE.bazel
@@ -1,0 +1,9 @@
+module(
+    name = "skywalking-data-collect-protocol",
+    version = "10.4.0.envoy",
+    compatibility_level = 1,
+    repo_name = "skywalking_data_collect_protocol",
+)
+
+bazel_dep(name = "grpc", version = "1.76.0.bcr.1.envoy", repo_name = "com_github_grpc_grpc")
+bazel_dep(name = "protobuf", version = "33.0", repo_name = "com_google_protobuf")

--- a/bazel-registry/modules/skywalking-data-collect-protocol/10.4.0.envoy/presubmit.yml
+++ b/bazel-registry/modules/skywalking-data-collect-protocol/10.4.0.envoy/presubmit.yml
@@ -1,0 +1,15 @@
+matrix:
+  platform:
+  - debian11
+  - ubuntu2404
+  - macos
+  bazel:
+  - 8.x
+
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - "@skywalking-data-collect-protocol//..."

--- a/bazel-registry/modules/skywalking-data-collect-protocol/10.4.0.envoy/source.json
+++ b/bazel-registry/modules/skywalking-data-collect-protocol/10.4.0.envoy/source.json
@@ -1,0 +1,5 @@
+{
+    "url": "https://github.com/apache/skywalking-data-collect-protocol/archive/v10.4.0.tar.gz",
+    "integrity": "sha256-cOY90w2d/c8KDvCXbhnH4h+hQRrxPsMUUr0do35XjjU=",
+    "strip_prefix": "skywalking-data-collect-protocol-10.4.0"
+}

--- a/bazel-registry/modules/skywalking-data-collect-protocol/metadata.json
+++ b/bazel-registry/modules/skywalking-data-collect-protocol/metadata.json
@@ -5,7 +5,8 @@
         "github:apache/skywalking-data-collect-protocol"
     ],
     "versions": [
-        "10.3.0.envoy"
+        "10.3.0.envoy",
+        "10.4.0.envoy"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
Add new versions for modules that are behind envoy's `repository_locations.bzl`:

- `skywalking-data-collect-protocol`: 10.3.0 -> 10.4.0
- `dd-trace-cpp`: 2.0.0 -> 2.1.1
- `aws-c-auth-testdata`: 0.9.5 -> 0.10.4
- `kafka_message`: 3.9.1 -> 3.9.2

Part of envoyproxy/envoy#46539